### PR TITLE
feat: Add immersive Guided Tour with progressive disclosure

### DIFF
--- a/progress.md
+++ b/progress.md
@@ -195,3 +195,17 @@ Project remains at **100% complete**, pushing the boundaries of WebGL realism.
 ### Percentage of Completion
 
 Project remains at **100% complete**, achieving a dense, photorealistic forest environment.
+
+## Progress - Session 14 (Guided Tour & Progressive Disclosure)
+
+### Achievements
+
+*   **Immersive Guided Tour:** Implemented a cinematic "Guided Tour" feature that takes control of the camera to showcase key points of interest (The Clearing, Ancient Guardian, Flowing Reflection, Deep Forest, Ascent).
+*   **Progressive Disclosure UI:** Designed a minimalist `TourOverlay` that reveals information contextually only when the camera arrives at a destination, adhering to the "progressive disclosure" principle.
+*   **Smooth Navigation:** Created a `TourController` using GSAP for buttery-smooth camera transitions (`power2.inOut`) and continuous, organic drift motion (`Math.sin`) during pauses.
+*   **Context Management:** Architected a robust `TourContext` to manage tour state, ensuring the 3D environment (Zone, Audio, Fog) updates dynamically as the tour progresses.
+*   **Safety & Polish:** Refactored `Navigation` to gracefully disable user input during the tour, preventing conflicts, and added glassmorphism UI elements consistent with the existing aesthetic.
+
+### Percentage of Completion
+
+Project remains at **100% complete**, now featuring a directed experience mode alongside free exploration.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import { Overlay } from './components/Overlay'
 import { UI } from './components/UI'
 import { AudioPlayer } from './components/AudioPlayer'
 import { Cursor } from './components/Cursor'
+import { TourProvider } from './components/TourContext'
+import { TourOverlay } from './components/TourOverlay'
 import { Zone } from './types'
 import './App.css'
 
@@ -13,21 +15,25 @@ function App() {
   const [audioEnabled, setAudioEnabled] = useState(false)
 
   return (
-    <div className="relative w-full h-screen overflow-hidden bg-black">
-      <div className="absolute inset-0 pointer-events-none z-[200] bg-grain opacity-[0.05] mix-blend-overlay"></div>
-      <Canvas
-        shadows
-        camera={{ position: [0, 5, 25], fov: 45 }}
-        dpr={[1, 2]}
-        gl={{ antialias: true, toneMappingExposure: 1.2 }}
-      >
-        <Experience currentZone={currentZone} />
-      </Canvas>
-      <UI audioEnabled={audioEnabled} onToggleAudio={() => setAudioEnabled(!audioEnabled)} />
-      <Overlay currentZone={currentZone} onZoneChange={setCurrentZone} />
-      <AudioPlayer enabled={audioEnabled} />
-      <Cursor />
-    </div>
+    <TourProvider>
+      <div className="relative w-full h-screen overflow-hidden bg-black">
+        <div className="absolute inset-0 pointer-events-none z-[200] bg-grain opacity-[0.05] mix-blend-overlay"></div>
+        <Canvas
+          shadows
+          camera={{ position: [0, 5, 25], fov: 45 }}
+          dpr={[1, 2]}
+          gl={{ antialias: true, toneMappingExposure: 1.2 }}
+        >
+          {/* We pass onZoneChange to Experience so the TourController can update the environment */}
+          <Experience currentZone={currentZone} onZoneChange={setCurrentZone} />
+        </Canvas>
+        <UI audioEnabled={audioEnabled} onToggleAudio={() => setAudioEnabled(!audioEnabled)} />
+        <Overlay currentZone={currentZone} onZoneChange={setCurrentZone} />
+        <TourOverlay />
+        <AudioPlayer enabled={audioEnabled} />
+        <Cursor />
+      </div>
+    </TourProvider>
   )
 }
 

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -9,16 +9,21 @@ import { Deer } from './Deer'
 import { Crane } from './Crane'
 import { Butterflies } from './Butterflies'
 import { Effects } from './Effects'
+import { TourController } from './TourController'
+import { useTour } from './TourContext'
 import { Zone } from '../types'
 
 interface ExperienceProps {
   currentZone: Zone
+  onZoneChange: (zone: Zone) => void
 }
 
-export function Experience({ currentZone }: ExperienceProps) {
+export function Experience({ currentZone, onZoneChange }: ExperienceProps) {
+  const { isActive } = useTour()
+
   return (
     <>
-      <Navigation />
+      <Navigation enabled={!isActive} />
       <Environment currentZone={currentZone} />
       <BambooForest currentZone={currentZone} />
       <Fireflies count={currentZone === 'DEEP_FOREST' ? 250 : 150} />
@@ -29,6 +34,7 @@ export function Experience({ currentZone }: ExperienceProps) {
       <Crane position={[-12, 0, 5]} rotation={[0, -Math.PI / 4, 0]} />
       <Butterflies count={8} />
       <Effects />
+      <TourController onZoneChange={onZoneChange} />
     </>
   )
 }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,7 +2,11 @@ import { useFrame, useThree } from '@react-three/fiber'
 import { useRef, useEffect } from 'react'
 import * as THREE from 'three'
 
-export function Navigation() {
+interface NavigationProps {
+  enabled?: boolean
+}
+
+export function Navigation({ enabled = true }: NavigationProps) {
   const { camera } = useThree()
   const moveState = useRef({
     forward: false,
@@ -32,8 +36,19 @@ export function Navigation() {
   const velocity = useRef(new THREE.Vector3())
   const direction = useRef(new THREE.Vector3())
 
+  // Reset state when disabled
+  useEffect(() => {
+    if (!enabled) {
+      moveState.current = { forward: false, backward: false, left: false, right: false }
+      touchState.current.active = false
+      mouseState.current.active = false
+      velocity.current.set(0, 0, 0)
+    }
+  }, [enabled])
+
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      if (!enabled) return
       switch (e.code) {
         case 'ArrowUp':
         case 'KeyW':
@@ -55,6 +70,7 @@ export function Navigation() {
     }
 
     const onKeyUp = (e: KeyboardEvent) => {
+      if (!enabled) return
       switch (e.code) {
         case 'ArrowUp':
         case 'KeyW':
@@ -77,6 +93,7 @@ export function Navigation() {
 
     // Touch handlers
     const onTouchStart = (e: TouchEvent) => {
+        if (!enabled) return
         touchState.current.active = true
         touchState.current.startX = e.touches[0].clientX
         touchState.current.startY = e.touches[0].clientY
@@ -85,7 +102,7 @@ export function Navigation() {
     }
 
     const onTouchMove = (e: TouchEvent) => {
-        if (!touchState.current.active) return
+        if (!enabled || !touchState.current.active) return
         touchState.current.currX = e.touches[0].clientX
         touchState.current.currY = e.touches[0].clientY
 
@@ -100,7 +117,7 @@ export function Navigation() {
     // Mouse handlers
     const onMouseDown = (e: MouseEvent) => {
       // Only trigger on left click
-      if (e.button !== 0) return
+      if (e.button !== 0 || !enabled) return
 
       mouseState.current.active = true
       mouseState.current.startX = e.clientX
@@ -110,7 +127,7 @@ export function Navigation() {
     }
 
     const onMouseMove = (e: MouseEvent) => {
-      if (!mouseState.current.active) return
+      if (!mouseState.current.active || !enabled) return
       mouseState.current.currX = e.clientX
       mouseState.current.currY = e.clientY
     }
@@ -146,9 +163,11 @@ export function Navigation() {
       window.removeEventListener('mouseup', onMouseUp)
       window.removeEventListener('mouseleave', onMouseLeave)
     }
-  }, [])
+  }, [enabled]) // Add enabled dependency to re-bind if needed, or just check enabled in handlers (which capture the prop if effect depends on it)
 
   useFrame((_state, delta) => {
+    if (!enabled) return
+
     const speed = 10.0 // Units per second
     const turnSpeed = 1.5
 

--- a/src/components/TourContext.tsx
+++ b/src/components/TourContext.tsx
@@ -1,0 +1,130 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react'
+import { Zone } from '../types'
+
+export interface TourStep {
+  position: [number, number, number]
+  target: [number, number, number]
+  zone: Zone
+  title: string
+  description: string
+  duration?: number // Optional duration override for transition
+}
+
+export const TOUR_STEPS: TourStep[] = [
+  {
+    position: [0, 4, 15],
+    target: [0, 2, 0],
+    zone: 'CLEARING',
+    title: 'The Clearing',
+    description: 'A sanctuary of light where the bamboo parts, revealing the sky above. Here, breath slows and the mind clears.',
+    duration: 3
+  },
+  {
+    position: [8, 1.5, 8],
+    target: [10, 1.0, 10], // Looking slightly down at the lantern base/mid
+    zone: 'GROVE',
+    title: 'The Ancient Guardian',
+    description: 'A solitary stone lantern, weathered by centuries of rain and moss. It stands as a silent witness to the passing seasons.',
+    duration: 4
+  },
+  {
+    position: [-10, 1.5, 3],
+    target: [-15, 0.5, 0],
+    zone: 'STREAM',
+    title: 'Flowing Reflection',
+    description: 'Water, the softest element, overcomes the hardest stone. Its gentle murmur is the forest\'s constant song.',
+    duration: 4
+  },
+  {
+    position: [-2, 1.2, -2],
+    target: [-5, 0.8, -5],
+    zone: 'DEEP_FOREST',
+    title: 'Life in the Shadows',
+    description: 'The forest breathes through its inhabitants. In the deep shade, life thrives in quiet harmony.',
+    duration: 3.5
+  },
+  {
+    position: [0, 8, 0],
+    target: [0, 20, 0], // Looking straight up
+    zone: 'GROVE',
+    title: 'Ascent',
+    description: 'Reaching for the light, rooted in darkness. The bamboo teaches us to bend without breaking.',
+    duration: 4
+  }
+]
+
+interface TourContextType {
+  isActive: boolean
+  currentStepIndex: number
+  isTransitioning: boolean
+  startTour: () => void
+  endTour: () => void
+  nextStep: () => void
+  prevStep: () => void
+  setTransitioning: (state: boolean) => void
+  currentStep: TourStep
+  steps: TourStep[]
+}
+
+const TourContext = createContext<TourContextType | undefined>(undefined)
+
+export function TourProvider({ children }: { children: ReactNode }) {
+  const [isActive, setIsActive] = useState(false)
+  const [currentStepIndex, setCurrentStepIndex] = useState(0)
+  const [isTransitioning, setIsTransitioning] = useState(false)
+
+  const startTour = () => {
+    setIsActive(true)
+    setCurrentStepIndex(0)
+    setIsTransitioning(true)
+  }
+
+  const endTour = () => {
+    setIsActive(false)
+    setCurrentStepIndex(0)
+    setIsTransitioning(false)
+  }
+
+  const nextStep = () => {
+    if (currentStepIndex < TOUR_STEPS.length - 1) {
+      setCurrentStepIndex(prev => prev + 1)
+      setIsTransitioning(true)
+    } else {
+      endTour()
+    }
+  }
+
+  const prevStep = () => {
+    if (currentStepIndex > 0) {
+      setCurrentStepIndex(prev => prev - 1)
+      setIsTransitioning(true)
+    }
+  }
+
+  const value = {
+    isActive,
+    currentStepIndex,
+    isTransitioning,
+    startTour,
+    endTour,
+    nextStep,
+    prevStep,
+    setTransitioning: setIsTransitioning,
+    currentStep: TOUR_STEPS[currentStepIndex],
+    steps: TOUR_STEPS
+  }
+
+  return (
+    <TourContext.Provider value={value}>
+      {children}
+    </TourContext.Provider>
+  )
+}
+
+export function useTour() {
+  const context = useContext(TourContext)
+  if (context === undefined) {
+    throw new Error('useTour must be used within a TourProvider')
+  }
+  return context
+}

--- a/src/components/TourController.tsx
+++ b/src/components/TourController.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react'
+import { useThree, useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
+import gsap from 'gsap'
+import { useTour } from './TourContext'
+import { Zone } from '../types'
+
+interface TourControllerProps {
+  onZoneChange: (zone: Zone) => void
+}
+
+export function TourController({ onZoneChange }: TourControllerProps) {
+  const { camera } = useThree()
+  const { isActive, currentStep, currentStepIndex, setTransitioning } = useTour()
+
+  // We use a ref to track where the camera should be looking
+  const lookAtTarget = useRef(new THREE.Vector3())
+  const isFirstRun = useRef(true)
+
+  // Sync isFirstRun
+  useEffect(() => {
+    if (!isActive) {
+        isFirstRun.current = true
+    }
+  }, [isActive])
+
+  useEffect(() => {
+    if (!isActive) return
+
+    setTransitioning(true)
+    onZoneChange(currentStep.zone)
+
+    // If starting the tour, snap the target to current view so we animate FROM there
+    if (isFirstRun.current) {
+        const direction = new THREE.Vector3(0, 0, -1)
+        direction.applyQuaternion(camera.quaternion)
+        // Set target 10 units away in front of camera
+        lookAtTarget.current.copy(camera.position).add(direction.multiplyScalar(10))
+        isFirstRun.current = false
+    }
+
+    const duration = currentStep.duration || 3.5
+
+    // 1. Animate Camera Position
+    gsap.to(camera.position, {
+      x: currentStep.position[0],
+      y: currentStep.position[1],
+      z: currentStep.position[2],
+      duration: duration,
+      ease: "power2.inOut",
+      onComplete: () => {
+        setTransitioning(false)
+      }
+    })
+
+    // 2. Animate LookAt Target
+    gsap.to(lookAtTarget.current, {
+      x: currentStep.target[0],
+      y: currentStep.target[1],
+      z: currentStep.target[2],
+      duration: duration,
+      ease: "power2.inOut"
+    })
+
+  }, [currentStepIndex, isActive, camera, currentStep, onZoneChange, setTransitioning])
+
+  useFrame((state) => {
+    if (!isActive) return
+
+    // Apply Drift (Breathing effect)
+    const time = state.clock.getElapsedTime()
+
+    const driftX = Math.sin(time * 0.5) * 0.2
+    const driftY = Math.cos(time * 0.3) * 0.2
+
+    // Clone target to avoid modifying the GSAP target ref permanently
+    const currentTarget = lookAtTarget.current.clone()
+    currentTarget.x += driftX
+    currentTarget.y += driftY
+
+    camera.lookAt(currentTarget)
+  })
+
+  return null
+}

--- a/src/components/TourOverlay.tsx
+++ b/src/components/TourOverlay.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react'
+import { useTour, TOUR_STEPS } from './TourContext'
+
+export function TourOverlay() {
+  const { isActive, currentStep, currentStepIndex, isTransitioning, nextStep, prevStep, startTour, endTour } = useTour()
+  const [showContent, setShowContent] = useState(false)
+
+  // Manage content visibility based on transition state
+  useEffect(() => {
+    if (isTransitioning) {
+      setShowContent(false)
+    } else {
+      // Small delay to allow camera to settle before text appears
+      const timer = setTimeout(() => {
+        setShowContent(true)
+      }, 500)
+      return () => clearTimeout(timer)
+    }
+  }, [isTransitioning, currentStepIndex])
+
+  if (!isActive) {
+    return (
+      <div className="fixed bottom-8 right-8 z-50 pointer-events-auto">
+        <button
+          onClick={startTour}
+          className="group relative px-6 py-3 bg-white/5 hover:bg-white/10 backdrop-blur-md border border-white/10 rounded-full transition-all duration-500 shadow-[0_4px_16px_rgba(0,0,0,0.3)] hover:scale-105"
+          data-cursor-text="Begin Journey"
+        >
+          <div className="flex items-center gap-3">
+            <span className="w-2 h-2 rounded-full bg-white/50 group-hover:bg-white transition-colors duration-500 animate-pulse"></span>
+            <span className="text-white/80 group-hover:text-white text-xs tracking-[0.2em] uppercase font-light">
+              Guided Tour
+            </span>
+          </div>
+        </button>
+      </div>
+    )
+  }
+
+  // Active Tour UI
+  return (
+    <div className="fixed inset-0 z-50 pointer-events-none flex flex-col justify-between p-8 md:p-12">
+
+      {/* Top Bar: Progress & Exit */}
+      <div className="flex justify-between items-start w-full pointer-events-auto">
+        {/* Progress Indicators */}
+        <div className="flex gap-2">
+            {TOUR_STEPS.map((_, idx) => (
+                <div
+                    key={idx}
+                    className={`h-1 rounded-full transition-all duration-500 ${
+                        idx === currentStepIndex ? 'w-8 bg-white' : 'w-2 bg-white/20'
+                    }`}
+                />
+            ))}
+        </div>
+
+        {/* Exit Button */}
+        <button
+            onClick={endTour}
+            className="group p-3 rounded-full bg-black/20 hover:bg-black/40 backdrop-blur border border-white/5 hover:border-white/20 transition-all duration-300"
+            aria-label="Exit Tour"
+            data-cursor-text="Exit"
+        >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" className="opacity-50 group-hover:opacity-100 transition-opacity">
+                <path d="M1 1L11 11M1 11L11 1" stroke="currentColor" strokeWidth="1" strokeLinecap="round"/>
+            </svg>
+        </button>
+      </div>
+
+      {/* Center/Bottom: Content Card */}
+      {/* Only show if not transitioning (or fading in) */}
+      <div className={`flex flex-col items-center justify-end flex-1 pb-12 transition-all duration-1000 ease-out transform ${
+          showContent && !isTransitioning
+            ? 'opacity-100 translate-y-0 filter-none'
+            : 'opacity-0 translate-y-8 blur-sm'
+      }`}>
+        <div className="relative max-w-lg w-full bg-black/40 backdrop-blur-xl border border-white/10 p-8 md:p-10 rounded-2xl shadow-2xl pointer-events-auto overflow-hidden">
+
+            {/* Decorative gradient blob */}
+            <div className="absolute top-0 right-0 w-32 h-32 bg-white/5 blur-3xl rounded-full pointer-events-none -translate-y-1/2 translate-x-1/2"></div>
+
+            {/* Title */}
+            <h2 className="font-serif text-2xl md:text-3xl text-white mb-2 italic tracking-wide">
+                {currentStep.title}
+            </h2>
+
+            <div className="w-12 h-[1px] bg-white/20 mb-6"></div>
+
+            {/* Description */}
+            <p className="font-sans font-light text-white/80 text-sm md:text-base leading-relaxed mb-8">
+                {currentStep.description}
+            </p>
+
+            {/* Navigation Controls */}
+            <div className="flex justify-between items-center w-full pt-4 border-t border-white/5">
+                <button
+                    onClick={prevStep}
+                    disabled={currentStepIndex === 0}
+                    className={`text-[10px] uppercase tracking-widest transition-colors ${
+                        currentStepIndex === 0 ? 'text-white/10 cursor-not-allowed' : 'text-white/40 hover:text-white'
+                    }`}
+                >
+                    Previous
+                </button>
+
+                <button
+                    onClick={nextStep}
+                    className="group flex items-center gap-3 px-5 py-2 bg-white/10 hover:bg-white/20 rounded-full transition-all duration-300"
+                    data-cursor-text={currentStepIndex === TOUR_STEPS.length - 1 ? "Finish" : "Next"}
+                >
+                    <span className="text-[10px] uppercase tracking-widest text-white font-medium">
+                        {currentStepIndex === TOUR_STEPS.length - 1 ? 'Finish Tour' : 'Next Step'}
+                    </span>
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" className="group-hover:translate-x-1 transition-transform">
+                        <path d="M1 6H11M11 6L7 2M11 6L7 10" stroke="white" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                </button>
+            </div>
+        </div>
+      </div>
+
+      {/* Bottom Spacer to balance layout */}
+      <div className="h-12 w-full"></div>
+    </div>
+  )
+}


### PR DESCRIPTION
Implemented a comprehensive "Guided Tour" feature that takes the user on a curated journey through the bamboo forest.

**Key Features:**
*   **Cinematic Camera Control:** Uses `gsap` for smooth bezier-curve transitions between key points of interest (Clearing, Lantern, Stream, Deep Forest).
*   **Progressive Disclosure:** Information cards fade in only after the camera arrives at a destination, preventing cognitive overload.
*   **Immersive Drift:** The camera applies a subtle "breathing" sine-wave motion when stationary to feel alive.
*   **Zone Integration:** The environment (lighting, fog, audio) automatically updates to match the current tour step.
*   **Glassmorphism UI:** A polished overlay consistent with the existing design language.

**Technical Details:**
*   `TourContext` manages global tour state.
*   `TourController` overrides manual `Navigation` (which is disabled via an `enabled` prop) and animates the camera using `useFrame` and `gsap`.
*   Verified via code review and DOM structure checks (visual screenshots limited by WebGL environment).

---
*PR created automatically by Jules for task [7407792518332944294](https://jules.google.com/task/7407792518332944294) started by @rajeshceg3*