### PR TITLE
Refine fauna motion for more organic behavior

### DIFF
--- a/src/components/Birds.tsx
+++ b/src/components/Birds.tsx
@@ -9,9 +9,10 @@ const MATCHING_FACTOR = 0.05
 const CENTERING_FACTOR = 0.0005
 const AVOID_FACTOR = 0.05
 const TURN_FACTOR = 0.2
-const MAX_SPEED = 0.3
-const MIN_SPEED = 0.15
+const MAX_SPEED = 0.28
+const MIN_SPEED = 0.12
 const BOUNDS = 80
+const DAMPING = 0.995
 
 export function Birds({ count = 30 }) {
   const meshRef = useRef<THREE.InstancedMesh>(null)
@@ -170,10 +171,22 @@ export function Birds({ count = 30 }) {
             vy = (vy / speed) * MAX_SPEED
             vz = (vz / speed) * MAX_SPEED
         } else if (speed < MIN_SPEED) {
-             vx = (vx / speed) * MIN_SPEED
-             vy = (vy / speed) * MIN_SPEED
-             vz = (vz / speed) * MIN_SPEED
+             if (speed > 1e-5) {
+               const scale = MIN_SPEED / speed
+               vx *= scale
+               vy *= scale
+               vz *= scale
+             } else {
+               const angle = Math.random() * Math.PI * 2
+               vx = Math.cos(angle) * MIN_SPEED
+               vy = (Math.random() - 0.5) * MIN_SPEED * 0.2
+               vz = Math.sin(angle) * MIN_SPEED
+             }
         }
+
+        vx *= DAMPING
+        vy *= DAMPING
+        vz *= DAMPING
 
         velocities[i*3] = vx
         velocities[i*3+1] = vy

--- a/src/components/Butterflies.tsx
+++ b/src/components/Butterflies.tsx
@@ -19,6 +19,7 @@ export function Butterflies({ count = 15 }) {
       const z = (Math.random() - 0.5) * 30
 
       tempObject.position.set(x, y, z)
+      tempObject.rotation.y = Math.random() * Math.PI * 2
       tempObject.updateMatrix()
       inst.push(tempObject.matrix.clone())
       off.push(Math.random() * 100) // Random time offset
@@ -42,8 +43,11 @@ export function Butterflies({ count = 15 }) {
         '#include <begin_vertex>',
         `
         #include <begin_vertex>
-        // Very fast flutter
-        float flap = sin(uTime * 25.0 + position.x * 10.0) * 0.4;
+        // Organic flutter with per-instance variation
+        float seed = instanceMatrix[3][0] * 0.17 + instanceMatrix[3][2] * 0.13;
+        float flapSpeed = mix(16.0, 30.0, fract(seed));
+        float flapAmp = mix(0.22, 0.45, fract(seed * 2.3));
+        float flap = sin(uTime * flapSpeed + seed * 10.0 + position.x * 12.0) * flapAmp;
         if (abs(position.x) > 0.01) {
             transformed.y += flap * abs(position.x);
         }
@@ -81,10 +85,10 @@ export function Butterflies({ count = 15 }) {
       const nY = simplex.noise(time * 0.5 + 100, i * 0.1)
       const nZ = simplex.noise(time * 0.5 + 200, i * 0.1)
 
-      const wanderRadius = 3.0
+      const wanderRadius = 1.8 + simplex.noise(i * 0.31, 42.0) * 1.0
 
       const x = home.x + nX * wanderRadius
-      const y = home.y + nY * 1.5 // Less vertical range
+      const y = THREE.MathUtils.clamp(home.y + nY * 1.1, 0.8, 5.8)
       const z = home.z + nZ * wanderRadius
 
       dummy.position.set(x, y, z)


### PR DESCRIPTION
### Motivation
- Reduce perceivable artificial motion in fauna so birds and butterflies move with calmer, more organic behavior consistent with the scene's design goals.

### Description
- `src/components/Butterflies.tsx`: randomized initial facing with `tempObject.rotation.y`, added per-instance flutter variation in the vertex shader (`seed`, `flapSpeed`, `flapAmp`), reduced wander radius and tightened vertical range with `THREE.MathUtils.clamp` to produce calmer flight paths.
- `src/components/Birds.tsx`: lowered `MAX_SPEED` and `MIN_SPEED`, added `DAMPING` to gently decay velocity, and hardened low-speed recovery to avoid divide-by-zero by using a safe scaling branch and randomized reinitialization when speed is effectively zero.
- Kept motion shader uniforms updated each frame and preserved instancing for performance by updating instance matrices and shader `uTime` uniforms in `useFrame`.

### Testing
- Performed a production build with `npm run build`, which completed successfully (`vite` build passed).
- Ran `npm run lint`, which could not complete because the repository lacks an ESLint configuration (script failure due to missing config).
- Attempted a visual validation via headless browser screenshot, but the screenshot attempt timed out in this environment (no image artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa7d87d648328b40b3de9f5b0b64c)