### PR TITLE
Optimize TourController.tsx useFrame for peak performance

### DIFF
--- a/src/components/TourController.tsx
+++ b/src/components/TourController.tsx
@@ -15,6 +15,7 @@ export function TourController({ onZoneChange }: TourControllerProps) {
 
   // We use a ref to track where the camera should be looking
   const lookAtTarget = useRef(new THREE.Vector3())
+  const currentTarget = useRef(new THREE.Vector3())
   const isFirstRun = useRef(true)
 
   // Sync isFirstRun
@@ -73,12 +74,12 @@ export function TourController({ onZoneChange }: TourControllerProps) {
     const driftX = Math.sin(time * 0.5) * 0.2
     const driftY = Math.cos(time * 0.3) * 0.2
 
-    // Clone target to avoid modifying the GSAP target ref permanently
-    const currentTarget = lookAtTarget.current.clone()
-    currentTarget.x += driftX
-    currentTarget.y += driftY
+    // Use pre-allocated target to avoid modifying the GSAP target ref permanently
+    currentTarget.current.copy(lookAtTarget.current)
+    currentTarget.current.x += driftX
+    currentTarget.current.y += driftY
 
-    camera.lookAt(currentTarget)
+    camera.lookAt(currentTarget.current)
   })
 
   return null


### PR DESCRIPTION
This commit addresses a performance bottleneck in `TourController.tsx` where a `THREE.Vector3` object was being instantiated (cloned) on every single frame inside `useFrame`. 

To maximize WebGL performance, especially on less powerful devices, object instantiation within the render loop must be strictly avoided. The `currentTarget` vector is now pre-allocated using `useRef` and mutated in-place via `.copy()` and direct property assignment (`x`, `y`), completely eliminating the garbage collection overhead associated with the previous implementation.

---
*PR created automatically by Jules for task [1923614208670975597](https://jules.google.com/task/1923614208670975597) started by @rajeshceg3*