### PR TITLE
Optimize 3D render loops for "beast mode" performance

### DIFF
--- a/src/components/Autofocus.tsx
+++ b/src/components/Autofocus.tsx
@@ -16,6 +16,7 @@ export function Autofocus({ dofRef, smoothTime = 0.2 }: AutofocusProps) {
     const aim = useRef(new THREE.Vector3(0, 0, 0))    // Where we want to focus
     const farPoint = useRef(new THREE.Vector3(0, 0, 0))
     const lastRaycast = useRef(0)
+    const intersectsArray = useRef<THREE.Intersection[]>([])
 
     useEffect(() => {
         // Enable layer 1 on camera so we can see objects on this layer
@@ -37,7 +38,8 @@ export function Autofocus({ dofRef, smoothTime = 0.2 }: AutofocusProps) {
 
             // Intersect with scene (recursive)
             // Since we set layers, it will only check objects on Layer 1
-            const intersects = raycaster.current.intersectObjects(scene.children, true)
+            intersectsArray.current.length = 0
+            const intersects = raycaster.current.intersectObjects(scene.children, true, intersectsArray.current)
 
             let hitPoint = null
 

--- a/src/components/Butterflies.tsx
+++ b/src/components/Butterflies.tsx
@@ -75,7 +75,8 @@ export function Butterflies({ count = 15 }) {
 
     const t = state.clock.getElapsedTime()
 
-    homes.forEach((home, i) => {
+    for (let i = 0; i < homes.length; i++) {
+      const home = homes[i]
       const off = offsets[i]
       const time = t + off
 
@@ -107,7 +108,7 @@ export function Butterflies({ count = 15 }) {
       dummy.scale.set(0.1, 0.1, 0.1)
       dummy.updateMatrix()
       meshRef.current!.setMatrixAt(i, dummy.matrix)
-    })
+    }
     meshRef.current.instanceMatrix.needsUpdate = true
   })
 

--- a/src/components/Deer.tsx
+++ b/src/components/Deer.tsx
@@ -4,6 +4,41 @@ import * as THREE from 'three'
 
 type DeerState = 'IDLE' | 'GRAZE' | 'WALK' | 'ALERT';
 
+function animateLeg(leg: THREE.Group | null, offset: number, isWalking: boolean, walkTime: number, delta: number) {
+    if (!leg) return
+
+    const legAmp = 0.3
+
+    if (isWalking) {
+        const phase = (walkTime + offset) % 1.0
+
+        if (phase < 0.5) {
+            // Stance Phase (Plant)
+            // Leg rotates backward linearly to counteract body forward motion
+            // Map 0..0.5 to 0.5..-0.5 rotation?
+            // Actually, just rotation.x
+            const p = phase / 0.5 // 0..1
+            leg.rotation.x = THREE.MathUtils.lerp(legAmp, -legAmp, p)
+            leg.position.y = -0.15 // Grounded (relative height)
+
+            // Knee straightens slightly?
+            // Simplified: just rotate hip
+        } else {
+            // Swing Phase (Lift)
+            const p = (phase - 0.5) / 0.5 // 0..1
+            // Parabolic lift
+            const lift = Math.sin(p * Math.PI) * 0.15
+            // Move forward
+            leg.rotation.x = THREE.MathUtils.lerp(-legAmp, legAmp, p)
+            leg.position.y = -0.15 + lift
+        }
+    } else {
+        // Idle stance
+        leg.rotation.x = THREE.MathUtils.lerp(leg.rotation.x, 0, delta * 5)
+        leg.position.y = THREE.MathUtils.lerp(leg.position.y, -0.15, delta * 5)
+    }
+}
+
 export function Deer(props: any) {
   const groupRef = useRef<THREE.Group>(null)
   const neckRef = useRef<THREE.Group>(null)
@@ -202,48 +237,13 @@ export function Deer(props: any) {
     // Stance: 0.0-0.5 (Leg moves back)
     // Swing: 0.5-1.0 (Leg moves forward and up)
 
-    const legAmp = 0.3
-
-    const animateLeg = (leg: THREE.Group, offset: number) => {
-        if (!leg) return
-
-        if (isWalking) {
-            const phase = (walkTime.current + offset) % 1.0
-
-            if (phase < 0.5) {
-                // Stance Phase (Plant)
-                // Leg rotates backward linearly to counteract body forward motion
-                // Map 0..0.5 to 0.5..-0.5 rotation?
-                // Actually, just rotation.x
-                const p = phase / 0.5 // 0..1
-                leg.rotation.x = THREE.MathUtils.lerp(legAmp, -legAmp, p)
-                leg.position.y = -0.15 // Grounded (relative height)
-
-                // Knee straightens slightly?
-                // Simplified: just rotate hip
-            } else {
-                // Swing Phase (Lift)
-                const p = (phase - 0.5) / 0.5 // 0..1
-                // Parabolic lift
-                const lift = Math.sin(p * Math.PI) * 0.15
-                // Move forward
-                leg.rotation.x = THREE.MathUtils.lerp(-legAmp, legAmp, p)
-                leg.position.y = -0.15 + lift
-            }
-        } else {
-            // Idle stance
-            leg.rotation.x = THREE.MathUtils.lerp(leg.rotation.x, 0, delta * 5)
-            leg.position.y = THREE.MathUtils.lerp(leg.position.y, -0.15, delta * 5)
-        }
-    }
-
     // Trot gait: Diagonal pairs
     // FL (0.0), BR (0.0)
     // FR (0.5), BL (0.5)
-    animateLeg(legFLRef.current!, 0.0)
-    animateLeg(legBRRef.current!, 0.0)
-    animateLeg(legFRRef.current!, 0.5)
-    animateLeg(legBLRef.current!, 0.5)
+    animateLeg(legFLRef.current, 0.0, isWalking, walkTime.current, delta)
+    animateLeg(legBRRef.current, 0.0, isWalking, walkTime.current, delta)
+    animateLeg(legFRRef.current, 0.5, isWalking, walkTime.current, delta)
+    animateLeg(legBLRef.current, 0.5, isWalking, walkTime.current, delta)
 
 
     // 3. Head/Neck Animation


### PR DESCRIPTION
Optimized components running high-frequency logic in `useFrame` to eliminate garbage collection (GC) pressure and avoid unnecessary object allocations. Specific changes include:
- `Deer.tsx`: Hoisted `animateLeg` out of the component to prevent recreating the function closure on every frame.
- `Butterflies.tsx`: Replaced `homes.forEach` with a traditional `for` loop to avoid closure allocation per frame.
- `Autofocus.tsx`: Passed a pre-allocated `useRef` array to `raycaster.intersectObjects` to prevent Three.js from instantiating a new array on every raycast execution. Included `intersectsArray.current.length = 0` to safely reuse the array without leaking intersections from previous frames.

---
*PR created automatically by Jules for task [9147861811545611946](https://jules.google.com/task/9147861811545611946) started by @rajeshceg3*