### PR TITLE
Performance: Offload foliage matrix initialization to Web Workers

### DIFF
--- a/src/components/BambooForest.tsx
+++ b/src/components/BambooForest.tsx
@@ -1,7 +1,6 @@
-import { useRef, useMemo, useEffect } from 'react'
+import { useRef, useMemo, useEffect, useState } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import * as THREE from 'three'
-import { SimplexNoise } from 'three-stdlib'
 import { Zone } from '../types'
 
 interface BambooForestProps {
@@ -47,6 +46,23 @@ export function BambooForest({ currentZone = 'GROVE', count = 15000 }: BambooFor
   const branchMeshRef = useRef<THREE.InstancedMesh | null>(null)
   const leafMeshRef = useRef<THREE.InstancedMesh | null>(null)
   const { camera } = useThree()
+
+  const [matrices, setMatrices] = useState<{ stalkInstances: Float32Array; branchInstances: Float32Array; leafInstances: Float32Array } | null>(null)
+
+  useEffect(() => {
+    // Initialize Web Worker
+    const worker = new Worker(new URL('../workers/bambooWorker.ts', import.meta.url), { type: 'module' })
+
+    worker.onmessage = (e) => {
+      setMatrices(e.data)
+    }
+
+    worker.postMessage({ count })
+
+    return () => {
+      worker.terminate()
+    }
+  }, [count])
 
   // Custom material setup for Bamboo Stalks
   const material = useMemo(() => {
@@ -493,144 +509,24 @@ export function BambooForest({ currentZone = 'GROVE', count = 15000 }: BambooFor
     return geo
   }, [])
 
-  const { stalkInstances, branchInstances, leafInstances } = useMemo(() => {
-    // Upper bounds for array allocation
-    const stalkArray = new Float32Array(count * 16)
-    // Assume average 5 branches per stalk, 3 leaves per branch
-    const branchArray = new Float32Array(count * 5 * 16)
-    const leafArray = new Float32Array(count * 5 * 3 * 16)
-
-    let stalkCount = 0
-    let branchCount = 0
-    let leafCount = 0
-
-    const tempStalk = new THREE.Object3D()
-    const tempBranch = new THREE.Object3D()
-    const tempLeaf = new THREE.Object3D()
-
-    const simplex = new SimplexNoise()
-
-    for (let i = 0; i < count; i++) {
-      let x = 0, z = 0
-      let valid = false
-
-      for (let attempt = 0; attempt < 10; attempt++) {
-        x = (Math.random() - 0.5) * 2000
-        z = (Math.random() - 0.5) * 2000
-
-        const noiseVal = simplex.noise(x * 0.015, z * 0.015);
-        const n = noiseVal * 0.5 + 0.5;
-
-        if (n < 0.45) continue;
-
-        const distToCenter = Math.sqrt(x * x + z * z)
-        const distToStream = Math.abs(x + z) / Math.sqrt(2)
-
-        if (distToStream < 6) continue
-        if (distToCenter < 5) continue
-
-        valid = true
-        break;
-      }
-
-      if (!valid) continue;
-
-      const rotationY = Math.random() * Math.PI * 2
-      const scale = 0.7 + Math.random() * 0.8
-
-      tempStalk.position.set(x, 2.5, z)
-      tempStalk.rotation.set(0, rotationY, 0)
-      tempStalk.scale.set(scale, scale, scale)
-      tempStalk.updateMatrix()
-      tempStalk.matrix.toArray(stalkArray, stalkCount * 16)
-      stalkCount++
-
-      const numNodes = 5;
-      for (let h = 0; h < numNodes; h++) {
-          const localY = -1.5 + h * 1.0 + (Math.random() * 0.2 - 0.1);
-          if (localY > 2.0) continue;
-
-          if (Math.random() > 0.3) {
-              const branchAngle = Math.random() * Math.PI * 2;
-
-              tempBranch.position.set(x, 2.5 + localY * scale, z);
-              tempBranch.rotation.set(0, branchAngle, 0);
-              tempBranch.rotateX(-Math.PI / 4 - Math.random() * 0.2);
-
-              const branchLen = 0.8 + Math.random() * 0.5;
-              tempBranch.scale.set(scale * 0.5, branchLen, scale * 0.5);
-
-              tempBranch.updateMatrix();
-
-              if (branchCount * 16 < branchArray.length) {
-                  tempBranch.matrix.toArray(branchArray, branchCount * 16)
-                  branchCount++
-              }
-
-              const tilt = Math.PI / 4 + 0.1;
-              const dy = Math.sin(tilt) * branchLen * scale;
-              const dr = Math.cos(tilt) * branchLen * scale;
-              const dx = Math.sin(branchAngle) * dr;
-              const dz = Math.cos(branchAngle) * dr;
-
-              const tipX = x + dx;
-              const tipY = (2.5 + localY * scale) + dy;
-              const tipZ = z + dz;
-
-              const numLeaves = 3 + Math.floor(Math.random() * 3);
-              for (let L = 0; L < numLeaves; L++) {
-                   const leafAngle = Math.random() * Math.PI * 2;
-
-                   tempLeaf.position.set(
-                       tipX + (Math.random() - 0.5) * 0.2,
-                       tipY + (Math.random() - 0.5) * 0.2,
-                       tipZ + (Math.random() - 0.5) * 0.2
-                   );
-
-                   tempLeaf.rotation.set(
-                       Math.random() * 0.5,
-                       leafAngle,
-                       Math.random() * 0.5
-                   );
-
-                   const leafScale = (0.5 + Math.random() * 0.5) * scale;
-                   tempLeaf.scale.set(leafScale, leafScale, leafScale);
-                   tempLeaf.updateMatrix();
-
-                   if (leafCount * 16 < leafArray.length) {
-                       tempLeaf.matrix.toArray(leafArray, leafCount * 16)
-                       leafCount++
-                   }
-              }
-          }
-      }
-    }
-
-    // Trim arrays
-    const validStalks = new Float32Array(stalkArray.buffer, 0, stalkCount * 16)
-    const validBranches = new Float32Array(branchArray.buffer, 0, branchCount * 16)
-    const validLeaves = new Float32Array(leafArray.buffer, 0, leafCount * 16)
-
-    return { stalkInstances: validStalks, branchInstances: validBranches, leafInstances: validLeaves, stalkCount, branchCount, leafCount }
-  }, [count])
-
   useEffect(() => {
+    if (!matrices) return
     if (meshRef.current) {
-        meshRef.current.count = stalkInstances.length / 16
-        meshRef.current.instanceMatrix.array.set(stalkInstances)
+        meshRef.current.count = matrices.stalkInstances.length / 16
+        meshRef.current.instanceMatrix.array.set(matrices.stalkInstances)
         meshRef.current.instanceMatrix.needsUpdate = true
     }
     if (branchMeshRef.current) {
-        branchMeshRef.current.count = branchInstances.length / 16
-        branchMeshRef.current.instanceMatrix.array.set(branchInstances)
+        branchMeshRef.current.count = matrices.branchInstances.length / 16
+        branchMeshRef.current.instanceMatrix.array.set(matrices.branchInstances)
         branchMeshRef.current.instanceMatrix.needsUpdate = true
     }
     if (leafMeshRef.current) {
-        leafMeshRef.current.count = leafInstances.length / 16
-        leafMeshRef.current.instanceMatrix.array.set(leafInstances)
+        leafMeshRef.current.count = matrices.leafInstances.length / 16
+        leafMeshRef.current.instanceMatrix.array.set(matrices.leafInstances)
         leafMeshRef.current.instanceMatrix.needsUpdate = true
     }
-  }, [stalkInstances, branchInstances, leafInstances])
+  }, [matrices])
 
   useFrame((state) => {
       const time = state.clock.getElapsedTime()
@@ -663,7 +559,7 @@ export function BambooForest({ currentZone = 'GROVE', count = 15000 }: BambooFor
                 if (meshRef) meshRef.current = node;
                 if (node) node.layers.enable(1);
             }}
-            args={[undefined, undefined, stalkInstances.length / 16]}
+            args={[undefined, undefined, count]}
             castShadow
             receiveShadow
         >
@@ -673,7 +569,7 @@ export function BambooForest({ currentZone = 'GROVE', count = 15000 }: BambooFor
 
         <instancedMesh
             ref={branchMeshRef}
-            args={[undefined, undefined, branchInstances.length / 16]}
+            args={[undefined, undefined, count * 5]}
             castShadow
             receiveShadow
             geometry={branchGeometry}
@@ -683,7 +579,7 @@ export function BambooForest({ currentZone = 'GROVE', count = 15000 }: BambooFor
 
         <instancedMesh
             ref={leafMeshRef}
-            args={[undefined, undefined, leafInstances.length / 16]}
+            args={[undefined, undefined, count * 5 * 3]}
             castShadow
             receiveShadow
             geometry={leafGeometry}

--- a/src/components/GroundCover.tsx
+++ b/src/components/GroundCover.tsx
@@ -1,11 +1,26 @@
-import { useRef, useMemo, useEffect } from 'react'
+import { useRef, useMemo, useEffect, useState } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import * as THREE from 'three'
-import { SimplexNoise } from 'three-stdlib'
 
 export function GroundCover({ count = 100000 }) {
   const meshRef = useRef<THREE.InstancedMesh>(null)
   const { camera } = useThree()
+  const [matrices, setMatrices] = useState<{ instanceMatrixArray: Float32Array; actualCount: number } | null>(null)
+
+  useEffect(() => {
+    // Initialize Web Worker
+    const worker = new Worker(new URL('../workers/grassWorker.ts', import.meta.url), { type: 'module' })
+
+    worker.onmessage = (e) => {
+      setMatrices(e.data)
+    }
+
+    worker.postMessage({ count })
+
+    return () => {
+      worker.terminate()
+    }
+  }, [count])
 
   const material = useMemo(() => {
     const mat = new THREE.MeshStandardMaterial({
@@ -234,80 +249,13 @@ export function GroundCover({ count = 100000 }) {
       return geo
   }, [])
 
-  const { instanceMatrixArray, actualCount } = useMemo(() => {
-    const array = new Float32Array(count * 16)
-    const tempObject = new THREE.Object3D()
-    const simplex = new SimplexNoise()
-    let validCount = 0
-
-    for (let i = 0; i < count; i++) {
-        let x = 0, z = 0
-        let valid = false
-
-        // Try to place grass
-        for(let attempt = 0; attempt < 5; attempt++) {
-            x = (Math.random() - 0.5) * 2000
-            z = (Math.random() - 0.5) * 2000
-
-            // Noise Clustering
-            // Match bamboo noise scale
-            const noiseVal = simplex.noise(x * 0.015, z * 0.015);
-            const n = noiseVal * 0.5 + 0.5;
-
-            // Bamboo is > 0.45.
-            // We want grass EVERYWHERE, but denser in clearings (< 0.45)
-            // and sparser in groves (> 0.45).
-
-            let probability = 1.0;
-            if (n > 0.45) {
-                // In bamboo grove -> Sparse grass
-                probability = 0.3;
-            } else {
-                // In clearing -> Dense grass
-                probability = 0.9;
-            }
-
-            // Random check against probability
-            if (Math.random() > probability) continue;
-
-            const distToStream = Math.abs(x + z) / Math.sqrt(2)
-            const distToCenter = Math.sqrt(x * x + z * z)
-
-            if (distToStream < 2) continue // Too close to water
-            if (distToCenter < 2) continue
-
-            valid = true;
-            break;
-        }
-
-        if (!valid) continue; // Skip this instance slot if couldn't place
-
-        const scale = 0.6 + Math.random() * 0.8 // Varied scale
-        tempObject.position.set(x, 0, z)
-
-        tempObject.rotation.y = Math.random() * Math.PI * 2
-        tempObject.rotation.x = (Math.random() - 0.5) * 0.3
-        tempObject.rotation.z = (Math.random() - 0.5) * 0.3
-
-        tempObject.scale.set(scale, scale, scale)
-        tempObject.updateMatrix()
-        tempObject.matrix.toArray(array, validCount * 16)
-        validCount++
-    }
-
-    // Create a correctly sized sub-array based on valid grass placements
-    const validArray = new Float32Array(array.buffer, 0, validCount * 16)
-
-    return { instanceMatrixArray: validArray, actualCount: validCount }
-  }, [count])
-
   useEffect(() => {
-    if (!meshRef.current) return
-    meshRef.current.count = actualCount;
+    if (!meshRef.current || !matrices) return
+    meshRef.current.count = matrices.actualCount;
     // We can directly update the instanceMatrix buffer to avoid iterating and calling setMatrixAt
-    meshRef.current.instanceMatrix.array.set(instanceMatrixArray);
+    meshRef.current.instanceMatrix.array.set(matrices.instanceMatrixArray);
     meshRef.current.instanceMatrix.needsUpdate = true
-  }, [instanceMatrixArray, actualCount])
+  }, [matrices])
 
   useFrame((state) => {
     if (material.userData.shader) {

--- a/src/workers/bambooWorker.ts
+++ b/src/workers/bambooWorker.ts
@@ -1,0 +1,129 @@
+import * as THREE from 'three'
+import { SimplexNoise } from 'three-stdlib'
+
+self.onmessage = (e: MessageEvent) => {
+  const { count } = e.data
+
+  const stalkArray = new Float32Array(count * 16)
+  const branchArray = new Float32Array(count * 5 * 16)
+  const leafArray = new Float32Array(count * 5 * 3 * 16)
+
+  let stalkCount = 0
+  let branchCount = 0
+  let leafCount = 0
+
+  const tempStalk = new THREE.Object3D()
+  const tempBranch = new THREE.Object3D()
+  const tempLeaf = new THREE.Object3D()
+
+  const simplex = new SimplexNoise()
+
+  for (let i = 0; i < count; i++) {
+    let x = 0, z = 0
+    let valid = false
+
+    for (let attempt = 0; attempt < 10; attempt++) {
+      x = (Math.random() - 0.5) * 2000
+      z = (Math.random() - 0.5) * 2000
+
+      const noiseVal = simplex.noise(x * 0.015, z * 0.015);
+      const n = noiseVal * 0.5 + 0.5;
+
+      if (n < 0.45) continue;
+
+      const distToCenter = Math.sqrt(x * x + z * z)
+      const distToStream = Math.abs(x + z) / Math.sqrt(2)
+
+      if (distToStream < 6) continue
+      if (distToCenter < 5) continue
+
+      valid = true
+      break;
+    }
+
+    if (!valid) continue;
+
+    const rotationY = Math.random() * Math.PI * 2
+    const scale = 0.7 + Math.random() * 0.8
+
+    tempStalk.position.set(x, 2.5, z)
+    tempStalk.rotation.set(0, rotationY, 0)
+    tempStalk.scale.set(scale, scale, scale)
+    tempStalk.updateMatrix()
+    tempStalk.matrix.toArray(stalkArray, stalkCount * 16)
+    stalkCount++
+
+    const numNodes = 5;
+    for (let h = 0; h < numNodes; h++) {
+        const localY = -1.5 + h * 1.0 + (Math.random() * 0.2 - 0.1);
+        if (localY > 2.0) continue;
+
+        if (Math.random() > 0.3) {
+            const branchAngle = Math.random() * Math.PI * 2;
+
+            tempBranch.position.set(x, 2.5 + localY * scale, z);
+            tempBranch.rotation.set(0, branchAngle, 0);
+            tempBranch.rotateX(-Math.PI / 4 - Math.random() * 0.2);
+
+            const branchLen = 0.8 + Math.random() * 0.5;
+            tempBranch.scale.set(scale * 0.5, branchLen, scale * 0.5);
+
+            tempBranch.updateMatrix();
+
+            if (branchCount * 16 < branchArray.length) {
+                tempBranch.matrix.toArray(branchArray, branchCount * 16)
+                branchCount++
+            }
+
+            const tilt = Math.PI / 4 + 0.1;
+            const dy = Math.sin(tilt) * branchLen * scale;
+            const dr = Math.cos(tilt) * branchLen * scale;
+            const dx = Math.sin(branchAngle) * dr;
+            const dz = Math.cos(branchAngle) * dr;
+
+            const tipX = x + dx;
+            const tipY = (2.5 + localY * scale) + dy;
+            const tipZ = z + dz;
+
+            const numLeaves = 3 + Math.floor(Math.random() * 3);
+            for (let L = 0; L < numLeaves; L++) {
+                 const leafAngle = Math.random() * Math.PI * 2;
+
+                 tempLeaf.position.set(
+                     tipX + (Math.random() - 0.5) * 0.2,
+                     tipY + (Math.random() - 0.5) * 0.2,
+                     tipZ + (Math.random() - 0.5) * 0.2
+                 );
+
+                 tempLeaf.rotation.set(
+                     Math.random() * 0.5,
+                     leafAngle,
+                     Math.random() * 0.5
+                 );
+
+                 const leafScale = (0.5 + Math.random() * 0.5) * scale;
+                 tempLeaf.scale.set(leafScale, leafScale, leafScale);
+                 tempLeaf.updateMatrix();
+
+                 if (leafCount * 16 < leafArray.length) {
+                     tempLeaf.matrix.toArray(leafArray, leafCount * 16)
+                     leafCount++
+                 }
+            }
+        }
+    }
+  }
+
+  const validStalks = new Float32Array(stalkArray.buffer, 0, stalkCount * 16)
+  const validBranches = new Float32Array(branchArray.buffer, 0, branchCount * 16)
+  const validLeaves = new Float32Array(leafArray.buffer, 0, leafCount * 16)
+
+  postMessage(
+    {
+        stalkInstances: validStalks,
+        branchInstances: validBranches,
+        leafInstances: validLeaves
+    },
+    { transfer: [validStalks.buffer, validBranches.buffer, validLeaves.buffer] }
+  )
+}

--- a/src/workers/grassWorker.ts
+++ b/src/workers/grassWorker.ts
@@ -1,0 +1,64 @@
+import * as THREE from 'three'
+import { SimplexNoise } from 'three-stdlib'
+
+self.onmessage = (e: MessageEvent) => {
+  const { count } = e.data
+
+  const array = new Float32Array(count * 16)
+  const tempObject = new THREE.Object3D()
+  const simplex = new SimplexNoise()
+  let validCount = 0
+
+  for (let i = 0; i < count; i++) {
+      let x = 0, z = 0
+      let valid = false
+
+      // Try to place grass
+      for(let attempt = 0; attempt < 5; attempt++) {
+          x = (Math.random() - 0.5) * 2000
+          z = (Math.random() - 0.5) * 2000
+
+          const noiseVal = simplex.noise(x * 0.015, z * 0.015);
+          const n = noiseVal * 0.5 + 0.5;
+
+          let probability = 1.0;
+          if (n > 0.45) {
+              probability = 0.3;
+          } else {
+              probability = 0.9;
+          }
+
+          if (Math.random() > probability) continue;
+
+          const distToStream = Math.abs(x + z) / Math.sqrt(2)
+          const distToCenter = Math.sqrt(x * x + z * z)
+
+          if (distToStream < 2) continue
+          if (distToCenter < 2) continue
+
+          valid = true;
+          break;
+      }
+
+      if (!valid) continue;
+
+      const scale = 0.6 + Math.random() * 0.8
+      tempObject.position.set(x, 0, z)
+
+      tempObject.rotation.y = Math.random() * Math.PI * 2
+      tempObject.rotation.x = (Math.random() - 0.5) * 0.3
+      tempObject.rotation.z = (Math.random() - 0.5) * 0.3
+
+      tempObject.scale.set(scale, scale, scale)
+      tempObject.updateMatrix()
+      tempObject.matrix.toArray(array, validCount * 16)
+      validCount++
+  }
+
+  const validArray = new Float32Array(array.buffer, 0, validCount * 16)
+
+  postMessage(
+    { instanceMatrixArray: validArray, actualCount: validCount },
+    { transfer: [validArray.buffer] }
+  )
+}


### PR DESCRIPTION
- Created `src/workers/grassWorker.ts` and `src/workers/bambooWorker.ts` to execute procedural `SimplexNoise` matrix generation logic.
- Rewrote `GroundCover.tsx` and `BambooForest.tsx` to mount with initial empty state/buffer counts, instantiate the relevant `Worker` instances, and dynamically apply the populated `Float32Array` instance matrices onto the meshes when they are passed back via `postMessage`.
- Leveraged `Transferable` object passing (`{ transfer: [buffer] }`) for zero-copy memory transfers between the worker and main thread to avoid memory spikes and eliminate frame drops.

---
*PR created automatically by Jules for task [18367564209431542629](https://jules.google.com/task/18367564209431542629) started by @rajeshceg3*