### PR TITLE
Refactor AudioPlayer to stem-based ambience mixing

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -7,129 +7,254 @@ interface AudioPlayerProps {
   isIdle?: boolean
 }
 
+type StemKey = 'wind' | 'birds' | 'insects' | 'stream'
+
+type ZoneMix = Record<Zone, Record<StemKey, number>>
+
+const ENABLE_RANDOM_ONESHOTS = true
+const CROSSFADE_TIME = 2.4
+const DETAIL_BLOOM = 0.018
+
+const ZONE_MIX: ZoneMix = {
+  CLEARING: {
+    wind: 0.07,
+    birds: 0.04,
+    insects: 0.02,
+    stream: 0.015,
+  },
+  GROVE: {
+    wind: 0.06,
+    birds: 0.032,
+    insects: 0.03,
+    stream: 0.02,
+  },
+  DEEP_FOREST: {
+    wind: 0.05,
+    birds: 0.018,
+    insects: 0.045,
+    stream: 0.0,
+  },
+  STREAM: {
+    wind: 0.04,
+    birds: 0.022,
+    insects: 0.028,
+    stream: 0.085,
+  },
+}
+
+const STREAM_DISTANCE_BY_ZONE: Record<Zone, number> = {
+  STREAM: 0.1,
+  GROVE: 0.45,
+  CLEARING: 0.62,
+  DEEP_FOREST: 0.84,
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value))
+
+function createStemBuffer(ctx: AudioContext, stem: StemKey): AudioBuffer {
+  const durationSec = 8
+  const frameCount = Math.floor(ctx.sampleRate * durationSec)
+  const buffer = ctx.createBuffer(1, frameCount, ctx.sampleRate)
+  const channel = buffer.getChannelData(0)
+
+  let lpState = 0
+  let hpState = 0
+
+  for (let i = 0; i < frameCount; i += 1) {
+    const t = i / ctx.sampleRate
+    const white = Math.random() * 2 - 1
+
+    if (stem === 'wind') {
+      lpState = lpState * 0.992 + white * 0.008
+      const gust = 0.65 + 0.35 * Math.sin(t * 0.5)
+      channel[i] = lpState * gust * 0.9
+      continue
+    }
+
+    if (stem === 'stream') {
+      lpState = lpState * 0.968 + white * 0.032
+      const sparkle = Math.sin(t * 8.7) * 0.2 + Math.sin(t * 13.4) * 0.1
+      channel[i] = (lpState * 0.75 + white * 0.2 + sparkle) * 0.65
+      continue
+    }
+
+    if (stem === 'insects') {
+      hpState = white - lpState * 0.97
+      lpState = lpState * 0.97 + white * 0.03
+      const trill = (Math.sin(t * 39) + Math.sin(t * 42.5)) * 0.08
+      channel[i] = (hpState * 0.35 + trill) * 0.45
+      continue
+    }
+
+    // distant birds bed: lightly tonal rustle, not prominent calls
+    const tonal = Math.sin(t * 17 + Math.sin(t * 0.4) * 0.8) * 0.22
+    const airy = white * 0.1 + Math.sin(t * 23.5) * 0.08
+    channel[i] = (tonal + airy) * 0.28
+  }
+
+  return buffer
+}
+
 export function AudioPlayer({ enabled, currentZone, isIdle = false }: AudioPlayerProps) {
   const audioCtxRef = useRef<AudioContext | null>(null)
   const isStartedRef = useRef(false)
-  const enabledRef = useRef(enabled)
 
-  // Audio Node Refs for modulation
-  const windGainRef = useRef<GainNode | null>(null)
-  const windFilterRef = useRef<BiquadFilterNode | null>(null)
-  const streamGainRef = useRef<GainNode | null>(null)
-  const birdsIntervalRef = useRef<number | null>(null)
+  const enabledRef = useRef(enabled)
+  const zoneRef = useRef(currentZone)
   const isIdleRef = useRef(isIdle)
+
+  const windGainRef = useRef<GainNode | null>(null)
+  const birdBedGainRef = useRef<GainNode | null>(null)
+  const insectGainRef = useRef<GainNode | null>(null)
+  const streamGainRef = useRef<GainNode | null>(null)
+  const streamPannerRef = useRef<StereoPannerNode | null>(null)
+  const windFilterRef = useRef<BiquadFilterNode | null>(null)
+
+  const ambienceMasterRef = useRef<GainNode | null>(null)
+  const oneShotBusRef = useRef<GainNode | null>(null)
+  const oneShotTimeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    enabledRef.current = enabled
+
+    if (audioCtxRef.current && isStartedRef.current) {
+      if (enabled) {
+        audioCtxRef.current.resume()
+      } else {
+        audioCtxRef.current.suspend()
+      }
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    zoneRef.current = currentZone
+  }, [currentZone])
 
   useEffect(() => {
     isIdleRef.current = isIdle
   }, [isIdle])
 
   useEffect(() => {
-    enabledRef.current = enabled
-
-    if (audioCtxRef.current && isStartedRef.current) {
-        if (enabled) {
-            audioCtxRef.current.resume()
-        } else {
-            audioCtxRef.current.suspend()
-        }
-    }
-  }, [enabled])
-
-  // Initialize Audio Graph
-  useEffect(() => {
     const initAudio = () => {
       if (audioCtxRef.current) return
 
-      const AudioContext = window.AudioContext || (window as any).webkitAudioContext
+      const AudioContext = window.AudioContext || (window as Window & { webkitAudioContext?: typeof window.AudioContext }).webkitAudioContext
+      if (!AudioContext) return
+
       const ctx = new AudioContext()
       audioCtxRef.current = ctx
 
-      // 1. Wind (White Noise + Lowpass)
-      const windBufferSize = 2 * ctx.sampleRate
-      const windBuffer = ctx.createBuffer(1, windBufferSize, ctx.sampleRate)
-      const windOutput = windBuffer.getChannelData(0)
-      for (let i = 0; i < windBufferSize; i++) {
-        windOutput[i] = Math.random() * 2 - 1
+      // Build stems once and keep looping sources cheap.
+      const stemBuffers: Record<StemKey, AudioBuffer> = {
+        wind: createStemBuffer(ctx, 'wind'),
+        birds: createStemBuffer(ctx, 'birds'),
+        insects: createStemBuffer(ctx, 'insects'),
+        stream: createStemBuffer(ctx, 'stream'),
       }
-      const windSource = ctx.createBufferSource()
-      windSource.buffer = windBuffer
-      windSource.loop = true
+
+      const ambienceMaster = ctx.createGain()
+      ambienceMaster.gain.value = 0.92
+      ambienceMasterRef.current = ambienceMaster
+
+      const oneShotBus = ctx.createGain()
+      oneShotBus.gain.value = 0.28
+      oneShotBusRef.current = oneShotBus
+
+      ambienceMaster.connect(ctx.destination)
+      oneShotBus.connect(ctx.destination)
 
       const windFilter = ctx.createBiquadFilter()
       windFilter.type = 'lowpass'
-      windFilter.frequency.value = 400
-      windFilter.Q.value = 0.5
+      windFilter.frequency.value = 550
+      windFilter.Q.value = 0.7
       windFilterRef.current = windFilter
 
       const windGain = ctx.createGain()
-      windGain.gain.value = 0.05
+      windGain.gain.value = 0
       windGainRef.current = windGain
 
-      windSource.connect(windFilter)
-      windFilter.connect(windGain)
-      windGain.connect(ctx.destination)
-      windSource.start()
+      const birdsGain = ctx.createGain()
+      birdsGain.gain.value = 0
+      birdBedGainRef.current = birdsGain
 
-      // 2. Stream (Pink-ish Noise + Bandpass)
-      const streamBufferSize = 2 * ctx.sampleRate
-      const streamBuffer = ctx.createBuffer(1, streamBufferSize, ctx.sampleRate)
-      const streamOutput = streamBuffer.getChannelData(0)
-      let b0 = 0, b1 = 0, b2 = 0, b3 = 0, b4 = 0, b5 = 0, b6 = 0
-      for (let i = 0; i < streamBufferSize; i++) {
-        const white = Math.random() * 2 - 1
-        b0 = 0.99886 * b0 + white * 0.0555179
-        b1 = 0.99332 * b1 + white * 0.0750759
-        b2 = 0.96900 * b2 + white * 0.1538520
-        b3 = 0.86650 * b3 + white * 0.3104856
-        b4 = 0.55000 * b4 + white * 0.5329522
-        b5 = -0.7616 * b5 - white * 0.0168980
-        streamOutput[i] = b0 + b1 + b2 + b3 + b4 + b5 + b6 + white * 0.5362
-        streamOutput[i] *= 0.11 // (roughly) compensate for gain
-        b6 = white * 0.115926
-      }
-      const streamSource = ctx.createBufferSource()
-      streamSource.buffer = streamBuffer
-      streamSource.loop = true
-
-      const streamFilter = ctx.createBiquadFilter()
-      streamFilter.type = 'bandpass'
-      streamFilter.frequency.value = 800
-      streamFilter.Q.value = 0.8
+      const insectsGain = ctx.createGain()
+      insectsGain.gain.value = 0
+      insectGainRef.current = insectsGain
 
       const streamGain = ctx.createGain()
-      streamGain.gain.value = 0 // Start muted
+      streamGain.gain.value = 0
       streamGainRef.current = streamGain
 
-      streamSource.connect(streamFilter)
-      streamFilter.connect(streamGain)
-      streamGain.connect(ctx.destination)
+      const streamPanner = ctx.createStereoPanner()
+      streamPanner.pan.value = 0
+      streamPannerRef.current = streamPanner
+
+      const windSource = ctx.createBufferSource()
+      windSource.buffer = stemBuffers.wind
+      windSource.loop = true
+      windSource.connect(windFilter)
+      windFilter.connect(windGain)
+      windGain.connect(ambienceMaster)
+
+      const birdsSource = ctx.createBufferSource()
+      birdsSource.buffer = stemBuffers.birds
+      birdsSource.loop = true
+      birdsSource.playbackRate.value = 0.96
+      birdsSource.connect(birdsGain)
+      birdsGain.connect(ambienceMaster)
+
+      const insectsSource = ctx.createBufferSource()
+      insectsSource.buffer = stemBuffers.insects
+      insectsSource.loop = true
+      insectsSource.playbackRate.value = 1.02
+      insectsSource.connect(insectsGain)
+      insectsGain.connect(ambienceMaster)
+
+      const streamSource = ctx.createBufferSource()
+      streamSource.buffer = stemBuffers.stream
+      streamSource.loop = true
+      streamSource.playbackRate.value = 0.98
+      streamSource.connect(streamPanner)
+      streamPanner.connect(streamGain)
+      streamGain.connect(ambienceMaster)
+
+      windSource.start()
+      birdsSource.start()
+      insectsSource.start()
       streamSource.start()
 
       isStartedRef.current = true
 
-      // Animate Wind
-      const modulateWind = () => {
-        if (!windFilterRef.current || !windGainRef.current || !audioCtxRef.current) return
-        const time = audioCtxRef.current.currentTime
-        // If idle, wind drops. If not, normal gusting.
-        const currentIsIdle = isIdleRef.current
-        const baseFreq = currentIsIdle ? 200 : 400
-        const varFreq = currentIsIdle ? 50 : 200
-        windFilterRef.current.frequency.setTargetAtTime(baseFreq + Math.sin(time * 0.2) * varFreq + Math.sin(time * 0.5) * (varFreq/2), time, 0.5)
-        requestAnimationFrame(modulateWind)
-      }
-      modulateWind()
+      // Keep procedural movement subtle; stems carry the core ambience.
+      const modulate = () => {
+        const currentCtx = audioCtxRef.current
+        if (!currentCtx) return
 
-      // Sync initial state
+        const now = currentCtx.currentTime
+        if (windFilterRef.current) {
+          const base = isIdleRef.current ? 500 : 620
+          const wobble = Math.sin(now * 0.23) * 55 + Math.sin(now * 0.41) * 25
+          windFilterRef.current.frequency.setTargetAtTime(base + wobble, now, 0.8)
+        }
+
+        if (streamPannerRef.current && zoneRef.current === 'STREAM') {
+          const drift = Math.sin(now * 0.11) * 0.18
+          streamPannerRef.current.pan.setTargetAtTime(drift, now, 1.2)
+        }
+
+        requestAnimationFrame(modulate)
+      }
+      modulate()
+
       if (!enabledRef.current) {
         ctx.suspend()
       }
     }
 
     const handleInteraction = () => {
-        if (!isStartedRef.current) {
-            initAudio()
-        }
+      if (!isStartedRef.current) {
+        initAudio()
+      }
     }
 
     window.addEventListener('click', handleInteraction, { once: true })
@@ -137,74 +262,134 @@ export function AudioPlayer({ enabled, currentZone, isIdle = false }: AudioPlaye
     window.addEventListener('keydown', handleInteraction, { once: true })
 
     return () => {
-      if (audioCtxRef.current) {
-          audioCtxRef.current.close()
+      if (oneShotTimeoutRef.current) {
+        window.clearTimeout(oneShotTimeoutRef.current)
       }
-      if (birdsIntervalRef.current) {
-          clearInterval(birdsIntervalRef.current)
+      if (audioCtxRef.current) {
+        audioCtxRef.current.close()
       }
       window.removeEventListener('click', handleInteraction)
       window.removeEventListener('touchstart', handleInteraction)
       window.removeEventListener('keydown', handleInteraction)
     }
-  }, []) // Empty deps, only run once
+  }, [])
 
-  // React to Zone and Idle changes
   useEffect(() => {
     if (!audioCtxRef.current || !isStartedRef.current) return
+
     const ctx = audioCtxRef.current
+    const zoneMix = ZONE_MIX[currentZone]
+    const detailBloom = isIdle ? DETAIL_BLOOM : 0
 
-    // Stream Volume
-    if (streamGainRef.current) {
-       const targetStreamVol = currentZone === 'STREAM' ? (isIdle ? 0.08 : 0.05) : 0.0
-       streamGainRef.current.gain.setTargetAtTime(targetStreamVol, ctx.currentTime, 2.0)
+    const fade = (node: GainNode | null, target: number, timeConstant = CROSSFADE_TIME) => {
+      if (!node) return
+      node.gain.setTargetAtTime(Math.max(0, target), ctx.currentTime, timeConstant)
     }
 
-    // Wind Volume (Drop when idle to reward stillness)
-    if (windGainRef.current) {
-        const targetWindVol = isIdle ? 0.02 : 0.05
-        windGainRef.current.gain.setTargetAtTime(targetWindVol, ctx.currentTime, 3.0)
+    fade(windGainRef.current, zoneMix.wind * (isIdle ? 0.9 : 1.0))
+    fade(birdBedGainRef.current, zoneMix.birds + detailBloom)
+    fade(insectGainRef.current, zoneMix.insects + detailBloom * 0.8)
+
+    const streamDistance = STREAM_DISTANCE_BY_ZONE[currentZone]
+    const attenuation = 1 / (1 + streamDistance * 3.3)
+    const streamTarget = zoneMix.stream * attenuation
+    fade(streamGainRef.current, streamTarget, 1.9)
+
+    if (streamPannerRef.current) {
+      const targetPan = currentZone === 'STREAM' ? clamp((0.5 - streamDistance) * 1.3, -0.65, 0.65) : 0
+      streamPannerRef.current.pan.setTargetAtTime(targetPan, ctx.currentTime, 1.4)
     }
 
-    // Procedural Birds (More frequent in Clearing/Grove, especially when idle)
-    if (birdsIntervalRef.current) {
-        clearInterval(birdsIntervalRef.current)
+    if (oneShotTimeoutRef.current) {
+      window.clearTimeout(oneShotTimeoutRef.current)
+      oneShotTimeoutRef.current = null
     }
 
-    const playBirdChirp = () => {
-        if (!enabledRef.current || !audioCtxRef.current) return
-        if (currentZone === 'DEEP_FOREST' && Math.random() > 0.2) return // Rare in deep forest
+    if (!ENABLE_RANDOM_ONESHOTS) return
 
-        const osc = ctx.createOscillator()
-        const gain = ctx.createGain()
+    const scheduleOneShot = () => {
+      if (!audioCtxRef.current || !oneShotBusRef.current) return
 
-        // Randomize pitch
-        const basePitch = 3000 + Math.random() * 2000
-        osc.frequency.setValueAtTime(basePitch, ctx.currentTime)
-        osc.frequency.exponentialRampToValueAtTime(basePitch - 500, ctx.currentTime + 0.1)
+      const activeCtx = audioCtxRef.current
+      const zone = zoneRef.current
+      const idle = isIdleRef.current
 
-        // Envelope
-        gain.gain.setValueAtTime(0, ctx.currentTime)
-        gain.gain.linearRampToValueAtTime(isIdle ? 0.08 : 0.04, ctx.currentTime + 0.02)
-        gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.1)
+      const minMs = idle ? 5200 : 4200
+      const maxMs = idle ? 11500 : 9200
+      const jitterMs = Math.floor(Math.random() * (maxMs - minMs + 1)) + minMs
 
-        osc.connect(gain)
-        gain.connect(ctx.destination)
+      oneShotTimeoutRef.current = window.setTimeout(() => {
+        if (!enabledRef.current || !oneShotBusRef.current) {
+          scheduleOneShot()
+          return
+        }
 
-        osc.start()
-        osc.stop(ctx.currentTime + 0.1)
+        const chance = Math.random()
+        if (chance > 0.35) {
+          const osc = activeCtx.createOscillator()
+          const gain = activeCtx.createGain()
+          const pan = activeCtx.createStereoPanner()
+
+          const basePitch = zone === 'CLEARING' ? 3000 : zone === 'GROVE' ? 2700 : 2300
+          const pitch = basePitch + Math.random() * 900
+          const duration = 0.14 + Math.random() * 0.1
+          const amp = idle ? 0.03 : 0.022
+
+          osc.type = 'sine'
+          osc.frequency.setValueAtTime(pitch, activeCtx.currentTime)
+          osc.frequency.exponentialRampToValueAtTime(pitch * 0.78, activeCtx.currentTime + duration)
+
+          gain.gain.setValueAtTime(0.0001, activeCtx.currentTime)
+          gain.gain.linearRampToValueAtTime(amp, activeCtx.currentTime + duration * 0.3)
+          gain.gain.exponentialRampToValueAtTime(0.0001, activeCtx.currentTime + duration)
+
+          pan.pan.value = (Math.random() - 0.5) * 0.9
+
+          osc.connect(gain)
+          gain.connect(pan)
+          pan.connect(oneShotBusRef.current)
+
+          osc.start()
+          osc.stop(activeCtx.currentTime + duration)
+        } else {
+          const noise = activeCtx.createBufferSource()
+          const burst = activeCtx.createBuffer(1, Math.floor(activeCtx.sampleRate * 0.16), activeCtx.sampleRate)
+          const data = burst.getChannelData(0)
+          for (let i = 0; i < data.length; i += 1) {
+            data[i] = (Math.random() * 2 - 1) * (1 - i / data.length)
+          }
+
+          const hp = activeCtx.createBiquadFilter()
+          hp.type = 'highpass'
+          hp.frequency.value = 2200 + Math.random() * 1800
+
+          const gain = activeCtx.createGain()
+          gain.gain.setValueAtTime(idle ? 0.02 : 0.014, activeCtx.currentTime)
+          gain.gain.exponentialRampToValueAtTime(0.0001, activeCtx.currentTime + 0.16)
+
+          const pan = activeCtx.createStereoPanner()
+          pan.pan.value = (Math.random() - 0.5) * 0.95
+
+          noise.buffer = burst
+          noise.connect(hp)
+          hp.connect(gain)
+          gain.connect(pan)
+          pan.connect(oneShotBusRef.current)
+          noise.start()
+        }
+
+        scheduleOneShot()
+      }, jitterMs)
     }
 
-    // Calculate bird frequency
-    let birdChance = 10000 // default rare
-    if (currentZone === 'CLEARING') birdChance = 4000
-    if (currentZone === 'GROVE') birdChance = 6000
-    if (isIdle) birdChance *= 0.7 // More birds when still
+    scheduleOneShot()
 
-    birdsIntervalRef.current = window.setInterval(() => {
-        if (Math.random() > 0.5) playBirdChirp()
-    }, birdChance)
-
+    return () => {
+      if (oneShotTimeoutRef.current) {
+        window.clearTimeout(oneShotTimeoutRef.current)
+        oneShotTimeoutRef.current = null
+      }
+    }
   }, [currentZone, isIdle, enabled])
 
   return null


### PR DESCRIPTION
### Motivation
- Replace the previous procedural-only ambience graph with a more stable, high-quality stem approach to reduce repetition and give precise mixing control. 
- Provide smooth, zone-driven crossfades and spatial emphasis for the stream so transitions feel natural instead of hard behavior switches. 
- Surface subtle detail during idle (a gentle "detail bloom") and add optional randomized one-shots so life feels varied without making procedural modulation the primary sound source.

### Description
- Introduced stem architecture and utilities: `StemKey`, `createStemBuffer`, `ZONE_MIX`, `STREAM_DISTANCE_BY_ZONE`, and constants `CROSSFADE_TIME`, `DETAIL_BLOOM`, and `ENABLE_RANDOM_ONESHOTS` in `src/components/AudioPlayer.tsx`.
- Replaced ad-hoc procedural noise sources with four prebuilt looping stems (`wind`, `birds`, `insects`, `stream`) created once and played via cheap `AudioBufferSourceNode`s routed through dedicated `GainNode`s and a master bus.
- Implemented smooth zone-driven crossfades by driving per-stem gains with `setTargetAtTime`, added stream distance attenuation and a `StereoPannerNode` for `STREAM` emphasis, and applied an idle-state detail bloom that raises fine-detail layers (birds/insects) rather than increasing global loudness.
- Added optional randomized one-shot scheduling (chirps and bursts with jittered timing and panning) routed through a `oneShotBus`, and kept procedural modulation (filter wobble and subtle panner drift) as a light enhancer only.

### Testing
- `npm run build` (which runs `tsc && vite build`) completed successfully and produced a production build. 
- `npm run lint` failed in this environment due to a missing ESLint configuration file (project-level configuration not present here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20c54e3bc8328a4539096ab1f9ed4)