### PR TITLE
Add adaptive quality controller with tiered LOD and post-processing scaling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,12 +9,22 @@ import { TourProvider } from './components/TourContext'
 import { TourOverlay } from './components/TourOverlay'
 import { Zone } from './types'
 import { useIdle } from './components/useIdle'
+import { QualityProvider, useQuality } from './components/QualityContext'
 import './App.css'
 
 function App() {
+  return (
+    <QualityProvider>
+      <AppScene />
+    </QualityProvider>
+  )
+}
+
+function AppScene() {
   const [currentZone, setCurrentZone] = useState<Zone>('GROVE')
   const [audioEnabled, setAudioEnabled] = useState(false)
   const isIdle = useIdle(5000)
+  const { dprRange } = useQuality()
 
   return (
     <TourProvider>
@@ -23,7 +33,7 @@ function App() {
         <Canvas
           shadows
           camera={{ position: [0, 5, 25], fov: 45 }}
-          dpr={[1, 2]}
+          dpr={dprRange}
           gl={{ antialias: true, toneMappingExposure: 1.2 }}
         >
           {/* We pass onZoneChange to Experience so the TourController can update the environment */}

--- a/src/components/Effects.tsx
+++ b/src/components/Effects.tsx
@@ -2,10 +2,15 @@ import { EffectComposer, Bloom, Noise, Vignette, ToneMapping, N8AO, DepthOfField
 import { ToneMappingMode } from 'postprocessing'
 import { useRef, useMemo } from 'react'
 import { Autofocus } from './Autofocus'
+import { useQuality } from './QualityContext'
 
 export function Effects() {
   const dofRef = useRef(null)
   const target = useMemo(() => [0, 0, 0] as [number, number, number], [])
+  const { tier } = useQuality()
+
+  const isHigh = tier === 'HIGH'
+  const isMedium = tier === 'MEDIUM'
 
   return (
     <EffectComposer enableNormalPass={false}>
@@ -13,23 +18,38 @@ export function Effects() {
           Actually, SMAA should be one of the last passes, but tone mapping and vignette are also last.
           Usually ToneMapping is very last. Let's put SMAA before Noise/Vignette/ToneMapping.
       */}
-      <SMAA />
-      <N8AO aoRadius={0.4} intensity={0.8} distanceFalloff={0.2} halfRes />
+      {isHigh || isMedium ? <SMAA /> : <></>}
+      {isHigh || isMedium ? (
+        <N8AO
+          aoRadius={isHigh ? 0.4 : 0.28}
+          intensity={isHigh ? 0.8 : 0.55}
+          distanceFalloff={isHigh ? 0.2 : 0.12}
+          halfRes
+        />
+      ) : (
+        <></>
+      )}
       <Bloom
         luminanceThreshold={1}
         mipmapBlur={false}
         intensity={0.8} // Reduced for subtlety and performance
         radius={0.4}
       />
-      <DepthOfField
-        ref={dofRef}
-        target={target}
-        focusDistance={0.0} // Dynamic
-        focalLength={0.02} // Realistic lens
-        bokehScale={2}
-        height={480}
-      />
-      <Autofocus dofRef={dofRef} />
+      {isHigh ? (
+        <>
+          <DepthOfField
+            ref={dofRef}
+            target={target}
+            focusDistance={0.0} // Dynamic
+            focalLength={0.02} // Realistic lens
+            bokehScale={2}
+            height={480}
+          />
+          <Autofocus dofRef={dofRef} />
+        </>
+      ) : (
+        <></>
+      )}
       <Noise opacity={0.05} />
       <Vignette eskil={false} offset={0.1} darkness={0.5} />
       <ToneMapping mode={ToneMappingMode.ACES_FILMIC} />

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -13,6 +13,7 @@ import { TourController } from './TourController'
 import { useTour } from './TourContext'
 import { Zone } from '../types'
 import { DustMotes } from './DustMotes'
+import { QualityFrameSampler, useQuality, type QualityTier } from './QualityContext'
 
 interface ExperienceProps {
   currentZone: Zone
@@ -22,22 +23,64 @@ interface ExperienceProps {
 
 export function Experience({ currentZone, onZoneChange, isIdle = false }: ExperienceProps) {
   const { isActive } = useTour()
+  const { tier } = useQuality()
+
+  const preset = getZoneLodPreset(currentZone, tier)
+  const dustCount = isIdle ? preset.dustIdle : preset.dust
 
   return (
     <>
+      <QualityFrameSampler />
       <Navigation enabled={!isActive} />
       <Environment currentZone={currentZone} />
-      <BambooForest currentZone={currentZone} />
-      <Fireflies count={currentZone === 'DEEP_FOREST' ? 250 : 150} isIdle={isIdle} />
-      <DustMotes count={isIdle ? 4000 : 2000} />
-      <Birds count={15} />
+      <BambooForest currentZone={currentZone} count={preset.bamboo} />
+      <Fireflies count={preset.fireflies} isIdle={isIdle} />
+      <DustMotes count={dustCount} />
+      <Birds count={preset.birds} />
       <Stream />
       <StoneLantern position={[10, 0, 10]} rotation={[0, Math.PI / 4, 0]} />
       <Deer position={[-5, 0, -5]} rotation={[0, Math.PI / 3, 0]} />
       <Crane position={[-12, 0, 5]} rotation={[0, -Math.PI / 4, 0]} />
-      <Butterflies count={8} />
+      <Butterflies count={preset.butterflies} />
       <Effects />
       <TourController onZoneChange={onZoneChange} />
     </>
   )
+}
+
+interface ZoneLodPreset {
+  bamboo: number
+  dust: number
+  dustIdle: number
+  fireflies: number
+  birds: number
+  butterflies: number
+}
+
+const zoneLodPresets: Record<Zone, Record<QualityTier, ZoneLodPreset>> = {
+  GROVE: {
+    HIGH: { bamboo: 15000, dust: 2000, dustIdle: 4000, fireflies: 150, birds: 15, butterflies: 8 },
+    MEDIUM: { bamboo: 11500, dust: 1400, dustIdle: 2600, fireflies: 105, birds: 11, butterflies: 6 },
+    LOW: { bamboo: 8500, dust: 900, dustIdle: 1800, fireflies: 70, birds: 8, butterflies: 4 },
+  },
+  CLEARING: {
+    HIGH: { bamboo: 12000, dust: 1600, dustIdle: 3200, fireflies: 120, birds: 14, butterflies: 10 },
+    MEDIUM: { bamboo: 9600, dust: 1200, dustIdle: 2200, fireflies: 85, birds: 10, butterflies: 7 },
+    LOW: { bamboo: 7000, dust: 800, dustIdle: 1600, fireflies: 60, birds: 7, butterflies: 5 },
+  },
+  STREAM: {
+    HIGH: { bamboo: 13000, dust: 1500, dustIdle: 2800, fireflies: 130, birds: 16, butterflies: 9 },
+    MEDIUM: { bamboo: 10100, dust: 1100, dustIdle: 2100, fireflies: 92, birds: 12, butterflies: 7 },
+    LOW: { bamboo: 7600, dust: 760, dustIdle: 1450, fireflies: 65, birds: 8, butterflies: 5 },
+  },
+  // Preserve dense ambience in deep forest even on lower tiers for perceptual richness.
+  DEEP_FOREST: {
+    HIGH: { bamboo: 18000, dust: 2600, dustIdle: 4800, fireflies: 250, birds: 18, butterflies: 10 },
+    MEDIUM: { bamboo: 15000, dust: 2100, dustIdle: 3800, fireflies: 205, birds: 14, butterflies: 8 },
+    LOW: { bamboo: 12500, dust: 1600, dustIdle: 3000, fireflies: 165, birds: 11, butterflies: 6 },
+  },
+}
+
+function getZoneLodPreset(zone: Zone, tier: QualityTier): ZoneLodPreset {
+  return zoneLodPresets[zone][tier]
 }

--- a/src/components/QualityContext.tsx
+++ b/src/components/QualityContext.tsx
@@ -1,0 +1,105 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useFrame } from '@react-three/fiber'
+
+export type QualityTier = 'LOW' | 'MEDIUM' | 'HIGH'
+
+interface QualityContextValue {
+  tier: QualityTier
+  dprRange: [number, number]
+  reportFrameTime: (frameTimeMs: number) => void
+}
+
+const QualityContext = createContext<QualityContextValue | null>(null)
+
+const tierRank: Record<QualityTier, number> = {
+  LOW: 0,
+  MEDIUM: 1,
+  HIGH: 2,
+}
+
+function clampTierFromViewport(): QualityTier {
+  if (typeof window === 'undefined') return 'MEDIUM'
+
+  const width = window.innerWidth
+  const height = window.innerHeight
+  const dpr = window.devicePixelRatio || 1
+  const renderPixels = width * height * dpr * dpr
+
+  // Conservative defaults for mobile/high-DPR devices.
+  if (renderPixels > 5_200_000 || dpr >= 2.75 || width < 900) return 'LOW'
+  if (renderPixels > 3_000_000 || dpr >= 2.1 || width < 1280) return 'MEDIUM'
+  return 'HIGH'
+}
+
+function dprRangeForTier(tier: QualityTier): [number, number] {
+  if (tier === 'LOW') return [0.75, 1.1]
+  if (tier === 'MEDIUM') return [0.9, 1.5]
+  return [1, 2]
+}
+
+export function QualityProvider({ children }: { children: ReactNode }) {
+  const [viewportTier, setViewportTier] = useState<QualityTier>(clampTierFromViewport)
+  const [runtimeTier, setRuntimeTier] = useState<QualityTier>('HIGH')
+
+  const frameWindowRef = useRef<number[]>([])
+  const cooldownRef = useRef(0)
+
+  useEffect(() => {
+    const onResize = () => {
+      setViewportTier(clampTierFromViewport())
+    }
+
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
+  const reportFrameTime = useCallback((frameTimeMs: number) => {
+    const frameWindow = frameWindowRef.current
+    frameWindow.push(frameTimeMs)
+    if (frameWindow.length > 45) frameWindow.shift()
+
+    cooldownRef.current += 1
+    if (frameWindow.length < 20 || cooldownRef.current < 20) return
+    cooldownRef.current = 0
+
+    const avgFrameTime = frameWindow.reduce((sum, value) => sum + value, 0) / frameWindow.length
+    // Hysteresis to avoid flickering between tiers.
+    const nextRuntimeTier: QualityTier =
+      avgFrameTime > 24 ? 'LOW' : avgFrameTime > 18 ? 'MEDIUM' : avgFrameTime < 14 ? 'HIGH' : runtimeTier
+
+    if (nextRuntimeTier !== runtimeTier) {
+      setRuntimeTier(nextRuntimeTier)
+    }
+  }, [runtimeTier])
+
+  const tier: QualityTier = useMemo(() => {
+    return tierRank[viewportTier] <= tierRank[runtimeTier] ? viewportTier : runtimeTier
+  }, [runtimeTier, viewportTier])
+
+  const value = useMemo<QualityContextValue>(() => ({
+    tier,
+    dprRange: dprRangeForTier(tier),
+    reportFrameTime,
+  }), [reportFrameTime, tier])
+
+  return <QualityContext.Provider value={value}>{children}</QualityContext.Provider>
+}
+
+export function QualityFrameSampler() {
+  const { reportFrameTime } = useQuality()
+
+  useFrame((_, delta) => {
+    reportFrameTime(delta * 1000)
+  })
+
+  return null
+}
+
+export function useQuality() {
+  const context = useContext(QualityContext)
+  if (!context) {
+    throw new Error('useQuality must be used within a QualityProvider')
+  }
+  return context
+}
+


### PR DESCRIPTION
### Motivation
- Centralize device and runtime quality decisions so rendering can adapt to viewport, DPR and observed frame-time without scattering logic across components.
- Reduce GPU/CPU load on constrained devices while preserving important perceptual richness (especially in the deep forest) by scaling counts and expensive effects by tier.
- Provide a stable runtime adaptation using frame-time sampling and hysteresis to avoid rapid flicker between quality levels.

### Description
- Add `src/components/QualityContext.tsx` which exposes `QualityProvider`, `useQuality`, `QualityFrameSampler`, a `QualityTier` (`LOW|MEDIUM|HIGH`), and `dprRange` derived from viewport DPR/size plus rolling frame-time sampling with hysteresis.
- Wrap the scene in `QualityProvider` and apply adaptive DPR clamping to the `<Canvas>` via `dpr={dprRange}` in `src/App.tsx` so DPR is more aggressively limited on low tiers.
- Wire quality into `src/components/Experience.tsx` by sampling frame-times (`QualityFrameSampler`) and selecting zone-specific LOD presets to scale `BambooForest`, `DustMotes`, `Fireflies`, `Birds`, and `Butterflies`, with explicit higher floors for `DEEP_FOREST` presets to preserve perceived richness.
- Wire quality into `src/components/Effects.tsx` to reduce or disable expensive passes per tier (HIGH: `SMAA` + `N8AO` + `DepthOfField`, MEDIUM: `SMAA` + reduced `N8AO`, LOW: disable `SMAA`/`N8AO`/`DOF`).

### Testing
- Ran the production build via `npm run build` which executes `tsc && vite build`, and the build completed successfully.
- The build produced the normal chunk-size warnings from Vite but exited with success (no TypeScript or runtime compile errors remained).
- No additional automated tests were added or required for this change set; the build validates type correctness and bundling for the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20ea626d0832882968761f79a8af1)