### PR TITLE
Tune navigation for contemplative default movement

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -14,18 +14,20 @@ interface NavigationProps {
   friction?: number
   smoothTime?: number
   toggleSprint?: boolean
+  advancedControls?: boolean
 }
 
 export function Navigation({
   enabled = true,
-  walkSpeed = 10.0,
-  runSpeed = 18.0,
+  walkSpeed = 6.0,
+  runSpeed = 10.0,
   jumpForce = 12.0,
-  lookSensitivity = 2.0,
-  acceleration = 5.0,
+  lookSensitivity = 1.4,
+  acceleration = 2.6,
   friction = 8.0,
-  smoothTime = 12.0,
-  toggleSprint = false
+  smoothTime = 6.0,
+  toggleSprint = false,
+  advancedControls = false
 }: NavigationProps) {
   const { camera, gl } = useThree()
 
@@ -172,6 +174,7 @@ export function Navigation({
           break
         case 'ShiftLeft':
         case 'ShiftRight':
+          if (!advancedControls) break
           if (toggleSprint) {
              moveState.current.sprint = !moveState.current.sprint
           } else {
@@ -179,6 +182,7 @@ export function Navigation({
           }
           break
         case 'Space':
+          if (!advancedControls) break
           if (onGround.current) {
              velocity.current.y = jumpForce
              onGround.current = false
@@ -208,6 +212,7 @@ export function Navigation({
           break
         case 'ShiftLeft':
         case 'ShiftRight':
+          if (!advancedControls) break
           if (!toggleSprint) {
              moveState.current.sprint = false
           }
@@ -384,7 +389,7 @@ export function Navigation({
       gl.domElement.removeEventListener('touchend', onTouchEnd)
       gl.domElement.removeEventListener('touchcancel', onTouchEnd)
     }
-  }, [enabled, gl.domElement, lookSensitivity, jumpForce, toggleSprint])
+  }, [enabled, gl.domElement, lookSensitivity, jumpForce, toggleSprint, advancedControls])
 
   // --- Physics Loop ---
 

--- a/src/components/UI.tsx
+++ b/src/components/UI.tsx
@@ -206,7 +206,7 @@ export const UI = ({ audioEnabled, onToggleAudio, isIdle = false }: UIProps) => 
                  <div className="w-8 h-8 rounded-full border border-white/40 flex items-center justify-center text-[8px] text-white/80">L</div>
                  <div className="w-8 h-8 rounded-full border border-white/40 flex items-center justify-center text-[8px] text-white/80">R</div>
                </div>
-               <span className="text-[8px] text-white/70">Explore • Look</span>
+               <span className="text-[8px] text-white/70">Wander • Observe</span>
             </div>
           ) : (
              <div className="flex flex-col items-center gap-2">
@@ -222,7 +222,7 @@ export const UI = ({ audioEnabled, onToggleAudio, isIdle = false }: UIProps) => 
                       <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><rect x="7" y="3" width="10" height="18" rx="5"></rect><line x1="12" y1="7" x2="12" y2="11"></line></svg>
                     </div>
                  </div>
-                 <span className="text-[8px] text-white/70">Explore • Look</span>
+                 <span className="text-[8px] text-white/70">Wander • Observe</span>
              </div>
           )}
         </div>


### PR DESCRIPTION
### Motivation
- Provide a calmer, more contemplative default movement profile for the experience.  
- Reduce abrupt camera/rotation response so looking feels damped and gentle.  
- Make sprint and jump opt-in behaviors so energetic controls are only available via an explicit toggle.

### Description
- Add an `advancedControls` prop (default `false`) to `Navigation` and gate sprint (`Shift`) and jump (`Space`) behind it so they are disabled by default (`src/components/Navigation.tsx`).
- Lower default movement/look tunables: `walkSpeed`, `runSpeed`, `acceleration`, `lookSensitivity`, and reduce the rotation smoothing factor via `smoothTime` to increase camera damping (`src/components/Navigation.tsx`).
- Include `advancedControls` in the `useEffect` dependency list for input handlers (`src/components/Navigation.tsx`).
- Update on-screen control hint copy from `Explore • Look` to `Wander • Observe` for both touch and keyboard HUD layouts to reinforce calm exploration (`src/components/UI.tsx`).

### Testing
- Ran `npm run build` (which executes `tsc && vite build`) and the production build completed successfully with a normal chunk-size warning; build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20eaa83488328845ce9e0510eb6de)