### PR TITLE
Improve motion accessibility and keyboard focus visibility

### DIFF
--- a/src/components/Cursor.tsx
+++ b/src/components/Cursor.tsx
@@ -10,7 +10,9 @@ export const Cursor = ({ isIdle = false }: { isIdle?: boolean }) => {
   useEffect(() => {
     // Only enable custom cursor on devices with fine pointers (mouse)
     const isFinePointer = window.matchMedia('(pointer: fine)').matches
-    if (isFinePointer) {
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    if (isFinePointer && !prefersReducedMotion) {
         setIsVisible(true)
     }
   }, [])
@@ -22,6 +24,8 @@ export const Cursor = ({ isIdle = false }: { isIdle?: boolean }) => {
     const textSpan = textRef.current
 
     if (!cursor) return
+
+    document.body.classList.add('cursor-enhanced')
 
     // Initial state
     gsap.set(cursor, { xPercent: -50, yPercent: -50 })
@@ -94,6 +98,7 @@ export const Cursor = ({ isIdle = false }: { isIdle?: boolean }) => {
     window.addEventListener('mouseup', onMouseUp)
 
     return () => {
+      document.body.classList.remove('cursor-enhanced')
       window.removeEventListener('mousemove', onMouseMove)
       window.removeEventListener('mouseover', onMouseOver)
       window.removeEventListener('mousedown', onMouseDown)

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -50,7 +50,7 @@ export function Overlay({ currentZone, onZoneChange, isIdle = false }: OverlayPr
               onClick={() => onZoneChange(zone)}
               className={`relative px-4 py-3 rounded-full transition-all duration-500 whitespace-nowrap ${
                 currentZone === zone ? 'bg-white/10 text-white shadow-inner' : 'text-white/40 hover:text-white/70 hover:bg-white/5'
-              }`}
+              } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-black`}
             >
               <span className="text-[9px] uppercase tracking-widest font-sans font-medium block text-center">
                 {zoneConfig[zone].name}
@@ -65,7 +65,7 @@ export function Overlay({ currentZone, onZoneChange, isIdle = false }: OverlayPr
             <button
               key={zone}
               onClick={() => onZoneChange(zone)}
-              className="group relative flex flex-col items-center justify-center w-4 h-16"
+              className="group relative flex flex-col items-center justify-center w-4 h-16 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-md"
               aria-label={`Go to ${zoneConfig[zone].name}`}
               data-cursor-text={zoneConfig[zone].name}
             >

--- a/src/components/TourOverlay.tsx
+++ b/src/components/TourOverlay.tsx
@@ -27,7 +27,7 @@ export function TourOverlay({ isIdle = false }: TourOverlayProps) {
       <div className={`fixed bottom-8 right-8 z-50 pointer-events-auto transition-opacity duration-1000 ${isIdle ? 'opacity-0' : 'opacity-100'}`}>
         <button
           onClick={startTour}
-          className="group relative px-5 py-4 rounded-full border border-white/20 flex items-center justify-center animate-pulse bg-black/10 backdrop-blur-md hover:bg-white/5 hover:border-white/40 transition-all duration-700 shadow-[0_4px_16px_rgba(0,0,0,0.3)] hover:scale-105"
+          className="group relative px-5 py-4 rounded-full border border-white/20 flex items-center justify-center animate-pulse bg-black/10 backdrop-blur-md hover:bg-white/5 hover:border-white/40 transition-all duration-700 shadow-[0_4px_16px_rgba(0,0,0,0.3)] hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
           data-cursor-text="Begin Journey"
         >
           <div className="flex items-center gap-3">
@@ -62,7 +62,7 @@ export function TourOverlay({ isIdle = false }: TourOverlayProps) {
         {/* Exit Button */}
         <button
             onClick={endTour}
-            className="group p-3 rounded-full bg-black/20 hover:bg-black/40 backdrop-blur border border-white/5 hover:border-white/20 transition-all duration-300"
+            className="group p-3 rounded-full bg-black/20 hover:bg-black/40 backdrop-blur border border-white/5 hover:border-white/20 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             aria-label="Exit Tour"
             data-cursor-text="Exit"
         >
@@ -101,7 +101,7 @@ export function TourOverlay({ isIdle = false }: TourOverlayProps) {
                 <button
                     onClick={prevStep}
                     disabled={currentStepIndex === 0}
-                    className={`text-[10px] uppercase tracking-widest transition-all duration-300 font-thin hover:underline underline-offset-4 decoration-1 decoration-white/30 ${
+                    className={`text-[10px] uppercase tracking-widest transition-all duration-300 font-thin hover:underline underline-offset-4 decoration-1 decoration-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-sm ${
                         currentStepIndex === 0 ? 'text-white/10 cursor-not-allowed hover:no-underline' : 'text-white/50 hover:text-white'
                     }`}
                 >
@@ -110,7 +110,7 @@ export function TourOverlay({ isIdle = false }: TourOverlayProps) {
 
                 <button
                     onClick={nextStep}
-                    className="group flex items-center gap-2 transition-all duration-300 font-thin hover:underline underline-offset-4 decoration-1 decoration-white/30"
+                    className="group flex items-center gap-2 transition-all duration-300 font-thin hover:underline underline-offset-4 decoration-1 decoration-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-sm"
                     data-cursor-text={currentStepIndex === TOUR_STEPS.length - 1 ? "Finish" : "Next"}
                 >
                     <span className="text-[10px] uppercase tracking-widest text-white/90 group-hover:text-white">

--- a/src/components/UI.tsx
+++ b/src/components/UI.tsx
@@ -19,7 +19,9 @@ const MagneticButton = ({ children, onClick, className = '', ariaLabel }: Magnet
     if (!btn) return
 
     // Only enable magnetic effect on fine pointers
-    if (window.matchMedia('(pointer: coarse)').matches) return
+    const isCoarsePointer = window.matchMedia('(pointer: coarse)').matches
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (isCoarsePointer || prefersReducedMotion) return
 
     const xTo = gsap.quickTo(btn, "x", { duration: 0.4, ease: "power3.out" })
     const yTo = gsap.quickTo(btn, "y", { duration: 0.4, ease: "power3.out" })
@@ -51,7 +53,7 @@ const MagneticButton = ({ children, onClick, className = '', ariaLabel }: Magnet
       ref={btnRef}
       onClick={onClick}
       aria-label={ariaLabel}
-      className={`relative ${className}`}
+      className={`relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${className}`}
     >
       {children}
     </button>
@@ -161,7 +163,7 @@ export const UI = ({ audioEnabled, onToggleAudio, isIdle = false }: UIProps) => 
 
           <button
             onClick={() => setStarted(true)}
-            className={`group relative px-12 py-4 overflow-hidden transition-all duration-[2000ms] delay-[1500ms] rounded-full border border-white/10 hover:bg-white/5 hover:border-white/20 backdrop-blur-3xl animate-breathe ${progress === 100 ? 'opacity-100' : 'opacity-0'}`}
+            className={`group relative px-12 py-4 overflow-hidden transition-all duration-[2000ms] delay-[1500ms] rounded-full border border-white/10 hover:bg-white/5 hover:border-white/20 backdrop-blur-3xl animate-breathe focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-black ${progress === 100 ? 'opacity-100' : 'opacity-0'}`}
           >
             <span className="relative z-10 font-sans text-[10px] md:text-xs tracking-[0.8em] uppercase text-white/50 group-hover:text-white/90 transition-colors duration-700">
               Enter

--- a/src/index.css
+++ b/src/index.css
@@ -19,12 +19,12 @@ body {
   color: black;
 }
 
-/* Hide cursor on fine pointer devices */
+/* Hide native cursor only after custom cursor JS initializes successfully. */
 @media (pointer: fine) {
-  body {
-    cursor: none;
-  }
-  a, button, [role="button"] {
+  body.cursor-enhanced,
+  body.cursor-enhanced a,
+  body.cursor-enhanced button,
+  body.cursor-enhanced [role="button"] {
     cursor: none;
   }
 }
@@ -68,3 +68,17 @@ canvas {
   .animate-breathe {
     animation: breathe 8s ease-in-out infinite;
   }
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-blur-in,
+  .animate-breathe {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+    filter: none !important;
+  }
+
+  .animate-blur-in {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- Reduce or disable motion-heavy animations for users that request reduced motion to prevent discomfort and provide a stable UI state.
- Keep the custom cursor feature usable without breaking fallback behavior when JS is unavailable or when assistive settings are active.
- Ensure interactive controls show visible keyboard focus for better keyboard navigation and accessibility.

### Description
- Added `@media (prefers-reduced-motion: reduce)` rules in `src/index.css` to disable the `animate-blur-in` and `animate-breathe` animation classes and remove blur/transform effects when reduced motion is requested.
- Changed cursor handling so the native cursor is hidden only when the custom cursor successfully initializes by toggling a `body.cursor-enhanced` class in `src/index.css` and `src/components/Cursor.tsx`, and the custom cursor is not activated when `prefers-reduced-motion` is set.
- Disabled the magnetic/elastic button effect when `prefers-reduced-motion: reduce` is active by short-circuiting the GSAP setup in `src/components/UI.tsx` (the `MagneticButton` hook now checks reduced-motion and pointer coarse/ fine conditions).
- Added keyboard-visible focus ring styles (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-black`) to interactive controls in `src/components/UI.tsx`, `src/components/Overlay.tsx`, and `src/components/TourOverlay.tsx` to improve keyboard navigation visibility.

### Testing
- `npm run build` completed successfully and produced a production build (`vite build`) with no build errors.
- `npm run lint` failed because the repository does not include an ESLint configuration (error: "ESLint couldn't find a configuration file").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20ec7995c8328a72acb6dfec2fc4e)